### PR TITLE
Restructure bot into modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# dietology_bot
+# Dietology Bot
+
+Simple aiogram bot for tracking meals and calculating macros.
+
+## Setup
+1. Install dependencies:
+   ```bash
+   pip install aiogram SQLAlchemy
+   ```
+2. Set your Telegram bot token in the environment variable `BOT_TOKEN`.
+3. Run the bot:
+   ```bash
+   python main.py
+   ```

--- a/app/data.py
+++ b/app/data.py
@@ -1,0 +1,1 @@
+pending_meals = {}

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,11 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from .models import Base
+
+engine = create_engine('sqlite:///bot.db')
+SessionLocal = sessionmaker(bind=engine)
+
+
+def init_db():
+    Base.metadata.create_all(engine)

--- a/app/handlers/__init__.py
+++ b/app/handlers/__init__.py
@@ -1,0 +1,3 @@
+from . import start, photo, callbacks, history, stats
+
+__all__ = ["start", "photo", "callbacks", "history", "stats"]

--- a/app/handlers/callbacks.py
+++ b/app/handlers/callbacks.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+
+from aiogram import types
+from aiogram.dispatcher import Dispatcher, FSMContext
+
+from ..data import pending_meals
+from ..db import SessionLocal
+from ..models import User, Meal
+from ..keyboards import meal_actions_keyboard
+from ..utils import format_meal_message
+from .photo import EditMeal
+from ..services import calculate_macros
+
+
+def setup(dp: Dispatcher):
+    @dp.callback_query_handler(lambda c: c.data.startswith("edit:"))
+    async def cb_edit(query: types.CallbackQuery, state: FSMContext):
+        meal_id = query.data.split(":", 1)[1]
+        await state.update_data(meal_id=meal_id)
+        await query.message.answer("Введите название и вес, напр. 'Яблоко 150'")
+        await EditMeal.waiting_input.set()
+        await query.answer()
+
+    @dp.callback_query_handler(lambda c: c.data.startswith("delete:"))
+    async def cb_delete(query: types.CallbackQuery):
+        meal_id = query.data.split(":", 1)[1]
+        pending_meals.pop(meal_id, None)
+        await query.message.delete()
+        await query.answer("Удалено")
+
+    @dp.callback_query_handler(lambda c: c.data.startswith("save:"))
+    async def cb_save(query: types.CallbackQuery):
+        meal_id = query.data.split(":", 1)[1]
+        meal = pending_meals.pop(meal_id, None)
+        if not meal:
+            await query.answer("Нечего сохранять", show_alert=True)
+            return
+
+        session = SessionLocal()
+        user = session.query(User).filter_by(telegram_id=query.from_user.id).first()
+        if not user:
+            user = User(telegram_id=query.from_user.id)
+            session.add(user)
+            session.commit()
+        new_meal = Meal(
+            user_id=user.id,
+            name=meal["name"],
+            ingredients=",".join(meal["ingredients"]),
+            serving=meal["serving"],
+            calories=meal["macros"]["calories"],
+            protein=meal["macros"]["protein"],
+            fat=meal["macros"]["fat"],
+            carbs=meal["macros"]["carbs"],
+        )
+        session.add(new_meal)
+        session.commit()
+        session.close()
+        await query.answer("Сохранено в историю!")

--- a/app/handlers/history.py
+++ b/app/handlers/history.py
@@ -1,0 +1,50 @@
+from aiogram import types
+from aiogram.dispatcher import Dispatcher
+
+from ..db import SessionLocal
+from ..models import User, Meal
+from ..utils import format_meal_message
+
+
+def send_history(user_id: int, chat_id: int, offset: int, bot):
+    session = SessionLocal()
+    q = session.query(Meal).join(User).filter(User.telegram_id == user_id).order_by(Meal.timestamp.desc())
+    total = q.count()
+    meal = q.offset(offset).limit(1).first()
+    session.close()
+    if not meal:
+        return bot.send_message(chat_id, "История пуста.")
+    markup = types.InlineKeyboardMarkup()
+    if offset > 0:
+        markup.insert(types.InlineKeyboardButton("\u2190", callback_data=f"hist:{offset-1}"))
+    if offset < total - 1:
+        markup.insert(types.InlineKeyboardButton("\u2192", callback_data=f"hist:{offset+1}"))
+    return bot.send_message(
+        chat_id,
+        format_meal_message(
+            meal.name,
+            meal.serving,
+            {
+                "calories": meal.calories,
+                "protein": meal.protein,
+                "fat": meal.fat,
+                "carbs": meal.carbs,
+            },
+        ),
+        reply_markup=markup,
+    )
+
+
+def setup(dp: Dispatcher):
+    bot = dp.bot
+
+    @dp.message_handler(commands=['history'])
+    async def cmd_history(message: types.Message):
+        await send_history(message.from_user.id, message.chat.id, 0, bot)
+
+    @dp.callback_query_handler(lambda c: c.data.startswith("hist:"))
+    async def cb_history(query: types.CallbackQuery):
+        offset = int(query.data.split(":", 1)[1])
+        await query.message.delete()
+        await send_history(query.from_user.id, query.message.chat.id, offset, bot)
+        await query.answer()

--- a/app/handlers/photo.py
+++ b/app/handlers/photo.py
@@ -1,0 +1,73 @@
+from datetime import datetime
+from typing import List
+
+from aiogram import types
+from aiogram.dispatcher import Dispatcher, FSMContext
+from aiogram.dispatcher.filters.state import StatesGroup, State
+
+from ..data import pending_meals
+from ..services import classify_food, recognize_dish, calculate_macros
+from ..keyboards import meal_actions_keyboard
+from ..utils import format_meal_message
+
+
+class EditMeal(StatesGroup):
+    waiting_input = State()
+
+
+def setup(dp: Dispatcher):
+    @dp.message_handler(content_types=types.ContentType.PHOTO)
+    async def handle_photo(message: types.Message, state: FSMContext):
+        await message.reply("Получил, анализирую…")
+        photo = message.photo[-1]
+        photo_file = await photo.download()
+        classification = await classify_food(photo_file.name)
+        if not classification["is_food"] or classification["confidence"] < 0.7:
+            await message.answer("Я не увидел еду на фото, попробуйте снова.")
+            return
+
+        dish = await recognize_dish(photo_file.name)
+        name = dish.get("name")
+        ingredients: List[str] = dish.get("ingredients", [])
+        serving = dish.get("serving", 0)
+
+        if not name:
+            markup = types.InlineKeyboardMarkup().add(
+                types.InlineKeyboardButton("Уточнить вес/ингр.", callback_data="refine")
+            )
+            await state.update_data(photo_path=photo_file.name, ingredients=ingredients, serving=serving)
+            await message.answer("Не смог распознать блюдо. Уточните вес/ингредиенты.", reply_markup=markup)
+            await EditMeal.waiting_input.set()
+            return
+
+        macros = await calculate_macros(ingredients, serving)
+        meal_id = f"{message.from_user.id}_{datetime.utcnow().timestamp()}"
+        pending_meals[meal_id] = {
+            "name": name,
+            "ingredients": ingredients,
+            "serving": serving,
+            "macros": macros,
+        }
+        await message.answer(format_meal_message(name, serving, macros), reply_markup=meal_actions_keyboard(meal_id))
+
+    @dp.message_handler(state=EditMeal.waiting_input)
+    async def process_edit(message: types.Message, state: FSMContext):
+        data = await state.get_data()
+        meal_id = data.get("meal_id", f"{message.from_user.id}_{datetime.utcnow().timestamp()}")
+        parts = message.text.split()
+        if len(parts) >= 2 and parts[-1].replace('.', '', 1).isdigit():
+            serving = float(parts[-1])
+            name = " ".join(parts[:-1])
+        else:
+            name = message.text
+            serving = 100.0
+        ingredients = [name]
+        macros = await calculate_macros(ingredients, serving)
+        pending_meals[meal_id] = {
+            "name": name,
+            "ingredients": ingredients,
+            "serving": serving,
+            "macros": macros,
+        }
+        await message.answer(format_meal_message(name, serving, macros), reply_markup=meal_actions_keyboard(meal_id))
+        await state.finish()

--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -1,0 +1,18 @@
+from aiogram import types
+from aiogram.dispatcher import Dispatcher
+
+from ..db import SessionLocal
+from ..models import User
+
+
+def setup(dp: Dispatcher):
+    @dp.message_handler(commands=['start'])
+    async def cmd_start(message: types.Message):
+        session = SessionLocal()
+        user = session.query(User).filter_by(telegram_id=message.from_user.id).first()
+        if not user:
+            user = User(telegram_id=message.from_user.id)
+            session.add(user)
+            session.commit()
+        session.close()
+        await message.reply("Привет! Отправь фото блюда, и я рассчитаю КБЖУ.")

--- a/app/handlers/stats.py
+++ b/app/handlers/stats.py
@@ -1,0 +1,51 @@
+from datetime import datetime, timedelta
+
+from aiogram import types
+from aiogram.dispatcher import Dispatcher
+
+from ..db import SessionLocal
+from ..models import User, Meal
+from ..keyboards import period_keyboard
+from ..utils import make_bar_chart
+
+
+def setup(dp: Dispatcher):
+    @dp.message_handler(commands=['stats'])
+    async def cmd_stats(message: types.Message):
+        await message.answer("Выберите период:", reply_markup=period_keyboard())
+
+    @dp.callback_query_handler(lambda c: c.data.startswith("stats:"))
+    async def cb_stats(query: types.CallbackQuery):
+        period = query.data.split(":", 1)[1]
+        session = SessionLocal()
+        user = session.query(User).filter_by(telegram_id=query.from_user.id).first()
+        if not user:
+            await query.answer("Нет данных", show_alert=True)
+            session.close()
+            return
+        now = datetime.utcnow()
+        if period == "day":
+            start = now - timedelta(days=1)
+        elif period == "week":
+            start = now - timedelta(weeks=1)
+        else:
+            start = now - timedelta(days=30)
+        meals = session.query(Meal).filter(Meal.user_id == user.id, Meal.timestamp >= start).all()
+        session.close()
+        if not meals:
+            await query.message.edit_text("Нет данных за выбранный период.")
+            await query.answer()
+            return
+        totals = {"calories": 0.0, "protein": 0.0, "fat": 0.0, "carbs": 0.0}
+        for m in meals:
+            totals["calories"] += m.calories
+            totals["protein"] += m.protein
+            totals["fat"] += m.fat
+            totals["carbs"] += m.carbs
+        text = (
+            f"Всего за период:\n"
+            f"{totals['calories']} ккал / {totals['protein']} г / {totals['fat']} г / {totals['carbs']} г\n\n"
+            f"{make_bar_chart(totals)}"
+        )
+        await query.message.edit_text(text)
+        await query.answer()

--- a/app/keyboards.py
+++ b/app/keyboards.py
@@ -1,0 +1,21 @@
+from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+
+
+def meal_actions_keyboard(meal_id: str) -> InlineKeyboardMarkup:
+    markup = InlineKeyboardMarkup(row_width=3)
+    markup.add(
+        InlineKeyboardButton("Редактировать", callback_data=f"edit:{meal_id}"),
+        InlineKeyboardButton("Удалить", callback_data=f"delete:{meal_id}"),
+        InlineKeyboardButton("В историю", callback_data=f"save:{meal_id}"),
+    )
+    return markup
+
+
+def period_keyboard() -> InlineKeyboardMarkup:
+    markup = InlineKeyboardMarkup(row_width=3)
+    markup.add(
+        InlineKeyboardButton("День", callback_data="stats:day"),
+        InlineKeyboardButton("Неделя", callback_data="stats:week"),
+        InlineKeyboardButton("Месяц", callback_data="stats:month"),
+    )
+    return markup

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+
+from sqlalchemy import Column, Integer, String, Float, DateTime, ForeignKey
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+
+class User(Base):
+    __tablename__ = 'users'
+
+    id = Column(Integer, primary_key=True)
+    telegram_id = Column(Integer, unique=True, index=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    meals = relationship('Meal', back_populates='user')
+
+
+class Meal(Base):
+    __tablename__ = 'meals'
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey('users.id'))
+    name = Column(String)
+    ingredients = Column(String)
+    serving = Column(Float)
+    calories = Column(Float)
+    protein = Column(Float)
+    fat = Column(Float)
+    carbs = Column(Float)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+
+    user = relationship('User', back_populates='meals')

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,20 @@
+from typing import List, Dict
+
+
+async def classify_food(photo_path: str) -> Dict[str, float]:
+    """Detect food vs non-food."""
+    return {"is_food": True, "confidence": 0.9}
+
+
+async def recognize_dish(photo_path: str) -> Dict[str, any]:
+    """Recognize dish name and ingredients."""
+    return {
+        "name": "Sample dish",
+        "ingredients": ["ingredient1", "ingredient2"],
+        "serving": 150,
+    }
+
+
+async def calculate_macros(ingredients: List[str], serving: float) -> Dict[str, float]:
+    """Calculate macros for given ingredients."""
+    return {"calories": 250, "protein": 20, "fat": 10, "carbs": 30}

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,18 @@
+from typing import Dict
+
+
+def format_meal_message(name: str, serving: float, macros: Dict[str, float]) -> str:
+    return (
+        f"\U0001F37D {name}\n"
+        f"\u2696 {serving} г\n"
+        f"\U0001F522 {macros['calories']} ккал / {macros['protein']} г / {macros['fat']} г / {macros['carbs']} г"
+    )
+
+
+def make_bar_chart(totals: Dict[str, float]) -> str:
+    max_val = max(totals.values()) if totals else 1
+    chart = ""
+    for key, val in totals.items():
+        bar = '█' * int((val / max_val) * 10)
+        chart += f"{key[:1].upper()}: {bar} {val}\n"
+    return chart

--- a/main.py
+++ b/main.py
@@ -1,0 +1,33 @@
+import os
+import logging
+
+from aiogram import Bot, Dispatcher
+from aiogram.contrib.fsm_storage.memory import MemoryStorage
+from aiogram.utils import executor
+
+from app.db import init_db
+from app.handlers import start, photo, callbacks, history, stats
+
+API_TOKEN = os.getenv("BOT_TOKEN", "YOUR_BOT_TOKEN")
+logging.basicConfig(level=logging.INFO)
+
+bot = Bot(token=API_TOKEN)
+dp = Dispatcher(bot, storage=MemoryStorage())
+
+
+def register_handlers():
+    start.setup(dp)
+    photo.setup(dp)
+    callbacks.setup(dp)
+    history.setup(dp)
+    stats.setup(dp)
+
+
+def main():
+    init_db()
+    register_handlers()
+    executor.start_polling(dp, skip_updates=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- reorganize the bot into a package with handlers and services
- add `main.py` entrypoint and database setup
- update README with run instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684d48de9b58832e80a53bbf3eaca609