### PR TITLE
Improve JSON parsing for OpenAI responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# dietology_bot
+# Dietology Bot
+
+Telegram bot for tracking meals and calculating macros. Built with `aiogram` and SQLite using SQLAlchemy.
+
+## Setup
+
+1. Install dependencies (Python 3.10+ recommended):
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set environment variables `BOT_TOKEN` (Telegram token) and optionally `OPENAI_API_KEY` for OpenAI integration. These values are read in `bot/config.py`.
+
+3. Run the bot (package version):
+   ```bash
+   python -m bot.main
+   ```
+   Or run the standalone file:
+   ```bash
+   python bot.py
+   ```
+
+The database is stored in `bot.db` in the project root by default. You can change this by setting `DATABASE_URL`.

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,334 @@
+import os
+import logging
+import asyncio
+from datetime import datetime, timedelta
+from typing import Dict, List
+
+from aiogram import Bot, Dispatcher, types, F
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+import tempfile
+from aiogram.filters import Command, StateFilter
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.storage.memory import MemoryStorage
+from aiogram.fsm.state import StatesGroup, State
+
+from bot.services import classify_food, recognize_dish, calculate_macros
+
+from sqlalchemy import (
+    create_engine, Column, Integer, String, Float, DateTime, ForeignKey
+)
+from sqlalchemy.orm import sessionmaker, declarative_base, relationship
+
+API_TOKEN = os.getenv("BOT_TOKEN", "YOUR_BOT_TOKEN")
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///bot.db")
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(bind=engine)
+Base = declarative_base()
+
+
+class User(Base):
+    __tablename__ = 'users'
+    id = Column(Integer, primary_key=True)
+    telegram_id = Column(Integer, unique=True, index=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    meals = relationship('Meal', back_populates='user')
+
+
+class Meal(Base):
+    __tablename__ = 'meals'
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey('users.id'))
+    name = Column(String)
+    ingredients = Column(String)
+    serving = Column(Float)
+    calories = Column(Float)
+    protein = Column(Float)
+    fat = Column(Float)
+    carbs = Column(Float)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+    user = relationship('User', back_populates='meals')
+
+
+Base.metadata.create_all(engine)
+
+
+class EditMeal(StatesGroup):
+    waiting_input = State()
+
+
+def format_meal_message(name: str, serving: float, macros: Dict[str, float]) -> str:
+    return (
+        f"\U0001F37D {name}\n"
+        f"\u2696 {serving} г\n"
+        f"\U0001F522 {macros['calories']} ккал / {macros['protein']} г / {macros['fat']} г / {macros['carbs']} г"
+    )
+
+
+def make_bar_chart(totals: Dict[str, float]) -> str:
+    max_val = max(totals.values()) if totals else 1
+    chart = ""
+    for key, val in totals.items():
+        bar = '█' * int((val / max_val) * 10)
+        chart += f"{key[:1].upper()}: {bar} {val}\n"
+    return chart
+
+
+def meal_actions_kb(meal_id: str) -> types.InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.button(text="Редактировать", callback_data=f"edit:{meal_id}")
+    builder.button(text="Удалить", callback_data=f"delete:{meal_id}")
+    builder.button(text="В историю", callback_data=f"save:{meal_id}")
+    builder.adjust(3)
+    return builder.as_markup()
+
+
+def history_nav_kb(offset: int, total: int) -> types.InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    if offset > 0:
+        builder.button(text="\u2190", callback_data=f"hist:{offset-1}")
+    if offset < total - 1:
+        builder.button(text="\u2192", callback_data=f"hist:{offset+1}")
+    if builder.buttons:
+        builder.adjust(len(builder.buttons))
+    return builder.as_markup()
+
+
+def stats_period_kb() -> types.InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.button(text="День", callback_data="stats:day")
+    builder.button(text="Неделя", callback_data="stats:week")
+    builder.button(text="Месяц", callback_data="stats:month")
+    builder.adjust(3)
+    return builder.as_markup()
+
+
+pending_meals: Dict[str, Dict] = {}
+
+
+async def cmd_start(message: types.Message):
+    session = SessionLocal()
+    user = session.query(User).filter_by(telegram_id=message.from_user.id).first()
+    if not user:
+        user = User(telegram_id=message.from_user.id)
+        session.add(user)
+        session.commit()
+    session.close()
+    await message.answer("Привет! Отправь фото блюда, и я рассчитаю КБЖУ.")
+
+
+async def handle_photo(message: types.Message, state: FSMContext):
+    await message.reply("Получил, анализирую…")
+    photo = message.photo[-1]
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        await message.bot.download(photo.file_id, destination=tmp.name)
+        photo_path = tmp.name
+    classification = await classify_food(photo_path)
+    if not classification['is_food'] or classification['confidence'] < 0.7:
+        await message.answer("Я не увидел еду на фото, попробуйте снова.")
+        return
+    dish = await recognize_dish(photo_path)
+    name = dish.get('name')
+    ingredients = dish.get('ingredients', [])
+    serving = dish.get('serving', 0)
+    if not name:
+        builder = InlineKeyboardBuilder()
+        builder.button(text="Уточнить вес/ингр.", callback_data="refine")
+        await state.update_data(photo_path=photo_path, ingredients=ingredients, serving=serving)
+        await message.answer(
+            "Не смог распознать блюдо. Уточните вес/ингредиенты.",
+            reply_markup=builder.as_markup(),
+        )
+        await state.set_state(EditMeal.waiting_input)
+        return
+    macros = await calculate_macros(ingredients, serving)
+    meal_id = f"{message.from_user.id}_{datetime.utcnow().timestamp()}"
+    pending_meals[meal_id] = {
+        'name': name,
+        'ingredients': ingredients,
+        'serving': serving,
+        'macros': macros,
+    }
+    await message.answer(
+        format_meal_message(name, serving, macros),
+        reply_markup=meal_actions_kb(meal_id)
+    )
+
+
+async def cb_edit(query: types.CallbackQuery, state: FSMContext):
+    meal_id = query.data.split(':', 1)[1]
+    await state.update_data(meal_id=meal_id)
+    await query.bot.send_message(query.from_user.id, "Введите название и вес, напр. 'Яблоко 150'")
+    await state.set_state(EditMeal.waiting_input)
+    await query.answer()
+
+
+async def process_edit(message: types.Message, state: FSMContext):
+    data = await state.get_data()
+    meal_id = data.get('meal_id', f"{message.from_user.id}_{datetime.utcnow().timestamp()}")
+    parts = message.text.split()
+    if len(parts) >= 2 and parts[-1].replace('.', '', 1).isdigit():
+        serving = float(parts[-1])
+        name = ' '.join(parts[:-1])
+    else:
+        name = message.text
+        serving = 100.0
+    ingredients = [name]
+    macros = await calculate_macros(ingredients, serving)
+    pending_meals[meal_id] = {
+        'name': name,
+        'ingredients': ingredients,
+        'serving': serving,
+        'macros': macros,
+    }
+    await message.answer(
+        format_meal_message(name, serving, macros),
+        reply_markup=meal_actions_kb(meal_id)
+    )
+    await state.clear()
+
+
+async def cb_delete(query: types.CallbackQuery):
+    meal_id = query.data.split(':', 1)[1]
+    pending_meals.pop(meal_id, None)
+    await query.message.delete()
+    await query.answer("Удалено")
+
+
+async def cb_save(query: types.CallbackQuery):
+    meal_id = query.data.split(':', 1)[1]
+    meal = pending_meals.pop(meal_id, None)
+    if not meal:
+        await query.answer("Нечего сохранять", show_alert=True)
+        return
+    session = SessionLocal()
+    user = session.query(User).filter_by(telegram_id=query.from_user.id).first()
+    if not user:
+        user = User(telegram_id=query.from_user.id)
+        session.add(user)
+        session.commit()
+    new_meal = Meal(
+        user_id=user.id,
+        name=meal['name'],
+        ingredients=','.join(meal['ingredients']),
+        serving=meal['serving'],
+        calories=meal['macros']['calories'],
+        protein=meal['macros']['protein'],
+        fat=meal['macros']['fat'],
+        carbs=meal['macros']['carbs'],
+    )
+    session.add(new_meal)
+    session.commit()
+    session.close()
+    await query.answer("Сохранено в историю!")
+
+
+async def send_history(bot: Bot, user_id: int, chat_id: int, offset: int):
+    session = SessionLocal()
+    q = session.query(Meal).join(User).filter(User.telegram_id == user_id).order_by(Meal.timestamp.desc())
+    total = q.count()
+    meal = q.offset(offset).limit(1).first()
+    session.close()
+    if not meal:
+        await bot.send_message(chat_id, "История пуста.")
+        return
+    await bot.send_message(
+        chat_id,
+        format_meal_message(
+            meal.name,
+            meal.serving,
+            {
+                'calories': meal.calories,
+                'protein': meal.protein,
+                'fat': meal.fat,
+                'carbs': meal.carbs,
+            },
+        ),
+        reply_markup=history_nav_kb(offset, total)
+    )
+
+
+async def cmd_history(message: types.Message):
+    await send_history(message.bot, message.from_user.id, message.chat.id, 0)
+
+
+async def cb_history(query: types.CallbackQuery):
+    offset = int(query.data.split(':', 1)[1])
+    await query.message.delete()
+    await send_history(query.bot, query.from_user.id, query.message.chat.id, offset)
+    await query.answer()
+
+
+async def cmd_stats(message: types.Message):
+    await message.answer("Выберите период:", reply_markup=stats_period_kb())
+
+
+async def cb_stats(query: types.CallbackQuery):
+    period = query.data.split(':', 1)[1]
+    session = SessionLocal()
+    user = session.query(User).filter_by(telegram_id=query.from_user.id).first()
+    if not user:
+        await query.answer("Нет данных", show_alert=True)
+        session.close()
+        return
+    now = datetime.utcnow()
+    if period == 'day':
+        start = now - timedelta(days=1)
+    elif period == 'week':
+        start = now - timedelta(weeks=1)
+    else:
+        start = now - timedelta(days=30)
+    meals = session.query(Meal).filter(Meal.user_id == user.id, Meal.timestamp >= start).all()
+    session.close()
+    if not meals:
+        await query.message.edit_text("Нет данных за выбранный период.")
+        await query.answer()
+        return
+    totals = {'calories': 0.0, 'protein': 0.0, 'fat': 0.0, 'carbs': 0.0}
+    for m in meals:
+        totals['calories'] += m.calories
+        totals['protein'] += m.protein
+        totals['fat'] += m.fat
+        totals['carbs'] += m.carbs
+    text = (
+        f"Всего за период:\n"
+        f"{totals['calories']} ккал / {totals['protein']} г / {totals['fat']} г / {totals['carbs']} г\n\n"
+        f"{make_bar_chart(totals)}"
+    )
+    await query.message.edit_text(text)
+    await query.answer()
+
+
+bot = Bot(token=API_TOKEN)
+dp = Dispatcher(storage=MemoryStorage())
+
+dp.message.register(cmd_start, Command('start'))
+dp.message.register(handle_photo, F.photo)
+dp.message.register(cmd_history, Command('history'))
+dp.message.register(cmd_stats, Command('stats'))
+
+dp.message.register(process_edit, StateFilter(EditMeal.waiting_input))
+
+dp.callback_query.register(cb_edit, F.data.startswith('edit:'))
+dp.callback_query.register(cb_delete, F.data.startswith('delete:'))
+dp.callback_query.register(cb_save, F.data.startswith('save:'))
+dp.callback_query.register(cb_history, F.data.startswith('hist:'))
+dp.callback_query.register(cb_stats, F.data.startswith('stats:'))
+
+async def handle_error(update: types.Update, exception: Exception) -> bool:
+    if isinstance(update, types.Message):
+        await update.answer("Произошла ошибка на сервере, попробуйте позже.")
+    elif isinstance(update, types.CallbackQuery):
+        await update.message.answer("Произошла ошибка на сервере, попробуйте позже.")
+    return True
+
+dp.errors.register(handle_error)
+
+
+async def main() -> None:
+    await dp.start_polling(bot)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(main())

--- a/bot/config.py
+++ b/bot/config.py
@@ -1,0 +1,7 @@
+import os
+
+# Centralized configuration for tokens and database
+
+API_TOKEN = os.getenv("BOT_TOKEN", "YOUR_BOT_TOKEN")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///bot.db")

--- a/bot/database.py
+++ b/bot/database.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+from sqlalchemy import create_engine, Column, Integer, String, Float, DateTime, ForeignKey
+from sqlalchemy.orm import sessionmaker, declarative_base, relationship
+
+from .config import DATABASE_URL
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(bind=engine)
+Base = declarative_base()
+
+class User(Base):
+    __tablename__ = 'users'
+    id = Column(Integer, primary_key=True)
+    telegram_id = Column(Integer, unique=True, index=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    meals = relationship('Meal', back_populates='user')
+
+class Meal(Base):
+    __tablename__ = 'meals'
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey('users.id'))
+    name = Column(String)
+    ingredients = Column(String)
+    serving = Column(Float)
+    calories = Column(Float)
+    protein = Column(Float)
+    fat = Column(Float)
+    carbs = Column(Float)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+    user = relationship('User', back_populates='meals')
+
+Base.metadata.create_all(engine)

--- a/bot/error_handler.py
+++ b/bot/error_handler.py
@@ -1,0 +1,8 @@
+from aiogram import types
+
+async def handle_error(update: types.Update, exception: Exception) -> bool:
+    if isinstance(update, types.Message):
+        await update.answer("Произошла ошибка на сервере, попробуйте позже.")
+    elif isinstance(update, types.CallbackQuery):
+        await update.message.answer("Произошла ошибка на сервере, попробуйте позже.")
+    return True

--- a/bot/handlers/__init__.py
+++ b/bot/handlers/__init__.py
@@ -1,0 +1,9 @@
+from . import start, photo, history, stats, callbacks
+
+__all__ = [
+    'start',
+    'photo',
+    'history',
+    'stats',
+    'callbacks',
+]

--- a/bot/handlers/callbacks.py
+++ b/bot/handlers/callbacks.py
@@ -1,0 +1,82 @@
+from datetime import datetime
+from aiogram import types, Dispatcher, F
+from aiogram.fsm.context import FSMContext
+from aiogram.filters import StateFilter
+
+from ..database import SessionLocal, User, Meal
+from ..services import calculate_macros
+from ..utils import format_meal_message
+from ..keyboards import meal_actions_kb
+from ..states import EditMeal
+from ..storage import pending_meals
+
+async def cb_edit(query: types.CallbackQuery, state: FSMContext):
+    meal_id = query.data.split(':', 1)[1]
+    await state.update_data(meal_id=meal_id)
+    await query.bot.send_message(query.from_user.id, "Введите название и вес, напр. 'Яблоко 150'")
+    await state.set_state(EditMeal.waiting_input)
+    await query.answer()
+
+async def process_edit(message: types.Message, state: FSMContext):
+    data = await state.get_data()
+    meal_id = data.get('meal_id', f"{message.from_user.id}_{datetime.utcnow().timestamp()}")
+    parts = message.text.split()
+    if len(parts) >= 2 and parts[-1].replace('.', '', 1).isdigit():
+        serving = float(parts[-1])
+        name = ' '.join(parts[:-1])
+    else:
+        name = message.text
+        serving = 100.0
+    ingredients = [name]
+    macros = await calculate_macros(ingredients, serving)
+    pending_meals[meal_id] = {
+        'name': name,
+        'ingredients': ingredients,
+        'serving': serving,
+        'macros': macros,
+    }
+    await message.answer(
+        format_meal_message(name, serving, macros),
+        reply_markup=meal_actions_kb(meal_id)
+    )
+    await state.clear()
+
+async def cb_delete(query: types.CallbackQuery):
+    meal_id = query.data.split(':', 1)[1]
+    pending_meals.pop(meal_id, None)
+    await query.message.delete()
+    await query.answer("Удалено")
+
+async def cb_save(query: types.CallbackQuery):
+    meal_id = query.data.split(':', 1)[1]
+    meal = pending_meals.pop(meal_id, None)
+    if not meal:
+        await query.answer("Нечего сохранять", show_alert=True)
+        return
+    session = SessionLocal()
+    user = session.query(User).filter_by(telegram_id=query.from_user.id).first()
+    if not user:
+        user = User(telegram_id=query.from_user.id)
+        session.add(user)
+        session.commit()
+    new_meal = Meal(
+        user_id=user.id,
+        name=meal['name'],
+        ingredients=','.join(meal['ingredients']),
+        serving=meal['serving'],
+        calories=meal['macros']['calories'],
+        protein=meal['macros']['protein'],
+        fat=meal['macros']['fat'],
+        carbs=meal['macros']['carbs'],
+    )
+    session.add(new_meal)
+    session.commit()
+    session.close()
+    await query.answer("Сохранено в историю!")
+
+
+def register(dp: Dispatcher):
+    dp.callback_query.register(cb_edit, F.data.startswith('edit:'))
+    dp.message.register(process_edit, StateFilter(EditMeal.waiting_input))
+    dp.callback_query.register(cb_delete, F.data.startswith('delete:'))
+    dp.callback_query.register(cb_save, F.data.startswith('save:'))

--- a/bot/handlers/history.py
+++ b/bot/handlers/history.py
@@ -1,0 +1,44 @@
+from aiogram import types, Dispatcher, Bot, F
+from aiogram.filters import Command
+
+from ..database import SessionLocal, Meal, User
+from ..utils import format_meal_message
+from ..keyboards import history_nav_kb
+
+async def send_history(bot: Bot, user_id: int, chat_id: int, offset: int):
+    session = SessionLocal()
+    q = session.query(Meal).join(User).filter(User.telegram_id == user_id).order_by(Meal.timestamp.desc())
+    total = q.count()
+    meal = q.offset(offset).limit(1).first()
+    session.close()
+    if not meal:
+        await bot.send_message(chat_id, "История пуста.")
+        return
+    await bot.send_message(
+        chat_id,
+        format_meal_message(
+            meal.name,
+            meal.serving,
+            {
+                'calories': meal.calories,
+                'protein': meal.protein,
+                'fat': meal.fat,
+                'carbs': meal.carbs,
+            },
+        ),
+        reply_markup=history_nav_kb(offset, total)
+    )
+
+async def cmd_history(message: types.Message):
+    await send_history(message.bot, message.from_user.id, message.chat.id, 0)
+
+async def cb_history(query: types.CallbackQuery):
+    offset = int(query.data.split(':', 1)[1])
+    await query.message.delete()
+    await send_history(query.bot, query.from_user.id, query.message.chat.id, offset)
+    await query.answer()
+
+
+def register(dp: Dispatcher):
+    dp.message.register(cmd_history, Command('history'))
+    dp.callback_query.register(cb_history, F.data.startswith('hist:'))

--- a/bot/handlers/photo.py
+++ b/bot/handlers/photo.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+from aiogram import types, Dispatcher, F
+import tempfile
+from aiogram.fsm.context import FSMContext
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+from ..services import classify_food, recognize_dish, calculate_macros
+from ..utils import format_meal_message
+from ..keyboards import meal_actions_kb
+from ..states import EditMeal
+from ..storage import pending_meals
+
+async def handle_photo(message: types.Message, state: FSMContext):
+    await message.reply("Получил, анализирую…")
+    photo = message.photo[-1]
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        await message.bot.download(photo.file_id, destination=tmp.name)
+        photo_path = tmp.name
+    classification = await classify_food(photo_path)
+    if not classification['is_food'] or classification['confidence'] < 0.7:
+        await message.answer("Я не увидел еду на фото, попробуйте снова.")
+        return
+
+    dish = await recognize_dish(photo_path)
+    name = dish.get('name')
+    ingredients = dish.get('ingredients', [])
+    serving = dish.get('serving', 0)
+
+    if not name:
+        builder = InlineKeyboardBuilder()
+        builder.button(text="Уточнить вес/ингр.", callback_data="refine")
+        await state.update_data(photo_path=photo_path, ingredients=ingredients, serving=serving)
+        await message.answer(
+            "Не смог распознать блюдо. Уточните вес/ингредиенты.",
+            reply_markup=builder.as_markup(),
+        )
+        await state.set_state(EditMeal.waiting_input)
+        return
+
+    macros = await calculate_macros(ingredients, serving)
+    meal_id = f"{message.from_user.id}_{datetime.utcnow().timestamp()}"
+    pending_meals[meal_id] = {
+        'name': name,
+        'ingredients': ingredients,
+        'serving': serving,
+        'macros': macros,
+    }
+
+    await message.answer(
+        format_meal_message(name, serving, macros),
+        reply_markup=meal_actions_kb(meal_id)
+    )
+
+
+def register(dp: Dispatcher):
+    dp.message.register(handle_photo, F.photo)

--- a/bot/handlers/start.py
+++ b/bot/handlers/start.py
@@ -1,0 +1,18 @@
+from aiogram import types, Dispatcher
+from aiogram.filters import Command
+
+from ..database import SessionLocal, User
+
+async def cmd_start(message: types.Message):
+    session = SessionLocal()
+    user = session.query(User).filter_by(telegram_id=message.from_user.id).first()
+    if not user:
+        user = User(telegram_id=message.from_user.id)
+        session.add(user)
+        session.commit()
+    session.close()
+    await message.reply("Привет! Отправь фото блюда, и я рассчитаю КБЖУ.")
+
+
+def register(dp: Dispatcher):
+    dp.message.register(cmd_start, Command('start'))

--- a/bot/handlers/stats.py
+++ b/bot/handlers/stats.py
@@ -1,0 +1,50 @@
+from datetime import datetime, timedelta
+from aiogram import types, Dispatcher, F
+from aiogram.filters import Command
+
+from ..database import SessionLocal, Meal, User
+from ..utils import make_bar_chart
+from ..keyboards import stats_period_kb
+
+async def cmd_stats(message: types.Message):
+    await message.answer("Выберите период:", reply_markup=stats_period_kb())
+
+async def cb_stats(query: types.CallbackQuery):
+    period = query.data.split(':', 1)[1]
+    session = SessionLocal()
+    user = session.query(User).filter_by(telegram_id=query.from_user.id).first()
+    if not user:
+        await query.answer("Нет данных", show_alert=True)
+        session.close()
+        return
+    now = datetime.utcnow()
+    if period == 'day':
+        start = now - timedelta(days=1)
+    elif period == 'week':
+        start = now - timedelta(weeks=1)
+    else:
+        start = now - timedelta(days=30)
+    meals = session.query(Meal).filter(Meal.user_id == user.id, Meal.timestamp >= start).all()
+    session.close()
+    if not meals:
+        await query.message.edit_text("Нет данных за выбранный период.")
+        await query.answer()
+        return
+    totals = {'calories': 0.0, 'protein': 0.0, 'fat': 0.0, 'carbs': 0.0}
+    for m in meals:
+        totals['calories'] += m.calories
+        totals['protein'] += m.protein
+        totals['fat'] += m.fat
+        totals['carbs'] += m.carbs
+    text = (
+        f"Всего за период:\n"
+        f"{totals['calories']} ккал / {totals['protein']} г / {totals['fat']} г / {totals['carbs']} г\n\n"
+        f"{make_bar_chart(totals)}"
+    )
+    await query.message.edit_text(text)
+    await query.answer()
+
+
+def register(dp: Dispatcher):
+    dp.message.register(cmd_stats, Command('stats'))
+    dp.callback_query.register(cb_stats, F.data.startswith('stats:'))

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -1,0 +1,30 @@
+from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+def meal_actions_kb(meal_id: str) -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.button(text="Редактировать", callback_data=f"edit:{meal_id}")
+    builder.button(text="Удалить", callback_data=f"delete:{meal_id}")
+    builder.button(text="В историю", callback_data=f"save:{meal_id}")
+    builder.adjust(3)
+    return builder.as_markup()
+
+
+def history_nav_kb(offset: int, total: int) -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    if offset > 0:
+        builder.button(text="\u2190", callback_data=f"hist:{offset-1}")
+    if offset < total - 1:
+        builder.button(text="\u2192", callback_data=f"hist:{offset+1}")
+    if builder.buttons:
+        builder.adjust(len(builder.buttons))
+    return builder.as_markup()
+
+
+def stats_period_kb() -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.button(text="День", callback_data="stats:day")
+    builder.button(text="Неделя", callback_data="stats:week")
+    builder.button(text="Месяц", callback_data="stats:month")
+    builder.adjust(3)
+    return builder.as_markup()

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,0 +1,28 @@
+import logging
+import asyncio
+from aiogram import Bot, Dispatcher
+from aiogram.fsm.storage.memory import MemoryStorage
+
+from .config import API_TOKEN
+from .handlers import start, photo, history, stats, callbacks
+from .error_handler import handle_error
+
+bot = Bot(token=API_TOKEN)
+dp = Dispatcher(storage=MemoryStorage())
+
+# register handlers
+start.register(dp)
+photo.register(dp)
+history.register(dp)
+stats.register(dp)
+callbacks.register(dp)
+
+dp.errors.register(handle_error)
+
+async def main() -> None:
+    await dp.start_polling(bot)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(main())

--- a/bot/services.py
+++ b/bot/services.py
@@ -1,0 +1,125 @@
+import json
+import base64
+import re
+from typing import Dict, List
+
+import openai
+
+from .config import OPENAI_API_KEY
+
+client = openai.AsyncOpenAI(api_key=OPENAI_API_KEY)
+
+
+async def _chat(messages: List[Dict]) -> str:
+    if not client.api_key:
+        return ""
+    try:
+        resp = await client.chat.completions.create(
+            model="gpt-4o",
+            messages=messages,
+            max_tokens=200,
+        )
+        return resp.choices[0].message.content
+    except Exception:
+        return ""
+
+
+async def classify_food(photo_path: str) -> Dict[str, float]:
+    """Detect food vs non-food using GPT-4o. Returns JSON."""
+    if not client.api_key:
+        return {"is_food": True, "confidence": 0.9}
+    with open(photo_path, "rb") as f:
+        b64 = base64.b64encode(f.read()).decode()
+    content = await _chat([
+        {
+            "role": "system",
+            "content": (
+                "Определи, изображена ли еда на фото. "
+                "Ответ только JSON вида {\"is_food\": bool, \"confidence\": 0-1}."
+            ),
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": f"data:image/jpeg;base64,{b64}",
+                }
+            ],
+        },
+    ])
+    try:
+        return json.loads(content)
+    except Exception:
+        match = re.search(r"\{.*\}", content)
+        if match:
+            try:
+                return json.loads(match.group(0))
+            except Exception:
+                pass
+        return {"is_food": False, "confidence": 0.0}
+
+
+async def recognize_dish(photo_path: str) -> Dict[str, any]:
+    """Recognize dish name and ingredients via GPT-4o."""
+    if not client.api_key:
+        return {
+            "name": "Sample dish",
+            "ingredients": ["ingredient1", "ingredient2"],
+            "serving": 150,
+        }
+    with open(photo_path, "rb") as f:
+        b64 = base64.b64encode(f.read()).decode()
+    content = await _chat([
+        {
+            "role": "system",
+            "content": (
+                "Определи блюдо на фото и перечисли основные ингредиенты "
+                "и примерный вес порции в граммах. "
+                "Ответ только JSON вида {name, ingredients, serving}."
+            ),
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": f"data:image/jpeg;base64,{b64}",
+                }
+            ],
+        },
+    ])
+    try:
+        return json.loads(content)
+    except Exception:
+        match = re.search(r"\{.*\}", content)
+        if match:
+            try:
+                return json.loads(match.group(0))
+            except Exception:
+                pass
+        return {"name": None, "ingredients": [], "serving": 0}
+
+
+async def calculate_macros(ingredients: List[str], serving: float) -> Dict[str, float]:
+    """Calculate approximate macros via GPT-4o."""
+    if not client.api_key:
+        return {"calories": 250, "protein": 20, "fat": 10, "carbs": 30}
+    prompt = (
+        "Рассчитай приблизительные калории, белки, жиры и углеводы для блюда "
+        f"из ингредиентов {', '.join(ingredients)} весом {serving} г. "
+        "Ответ только JSON вида {calories, protein, fat, carbs}."
+    )
+    content = await _chat([
+        {"role": "system", "content": prompt}
+    ])
+    try:
+        return json.loads(content)
+    except Exception:
+        match = re.search(r"\{.*\}", content)
+        if match:
+            try:
+                return json.loads(match.group(0))
+            except Exception:
+                pass
+        return {"calories": 0, "protein": 0, "fat": 0, "carbs": 0}

--- a/bot/states.py
+++ b/bot/states.py
@@ -1,0 +1,4 @@
+from aiogram.fsm.state import StatesGroup, State
+
+class EditMeal(StatesGroup):
+    waiting_input = State()

--- a/bot/storage.py
+++ b/bot/storage.py
@@ -1,0 +1,3 @@
+from typing import Dict
+
+pending_meals: Dict[str, Dict] = {}

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -1,0 +1,16 @@
+from typing import Dict
+
+def format_meal_message(name: str, serving: float, macros: Dict[str, float]) -> str:
+    return (
+        f"\U0001F37D {name}\n"
+        f"\u2696 {serving} г\n"
+        f"\U0001F522 {macros['calories']} ккал / {macros['protein']} г / {macros['fat']} г / {macros['carbs']} г"
+    )
+
+def make_bar_chart(totals: Dict[str, float]) -> str:
+    max_val = max(totals.values()) if totals else 1
+    chart = ""
+    for key, val in totals.items():
+        bar = '█' * int((val / max_val) * 10)
+        chart += f"{key[:1].upper()}: {bar} {val}\n"
+    return chart

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+aiogram>=3
+sqlalchemy
+openai


### PR DESCRIPTION
## Summary
- handle non-JSON OpenAI responses by extracting the JSON block
- fall back to a default when parsing fails
- use OpenAI helper services in the single-file bot
- clarify standalone vs package usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `BOT_TOKEN=dummy python -m bot.main` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_684d48de9b58832e80a53bbf3eaca609