### PR TITLE
Add manual notification command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Two helper commands imitate payment results:
 ```
 /success1467  # activate or extend paid plan
 /refused1467  # simulate payment refusal
+/notify1467  # force sending pending subscription reminders
 ```
 
 Paid users receive 800 GPT requests per month. Free users get 20 requests that renew every month from the account start date. Daily checks send reminders 7 and 3 days before expiry and on the last day.

--- a/bot/handlers/subscription.py
+++ b/bot/handlers/subscription.py
@@ -3,10 +3,11 @@ from aiogram import types, Dispatcher
 from aiogram.filters import Command
 
 from ..database import SessionLocal
-from ..subscriptions import ensure_user, process_payment_success
+from ..subscriptions import ensure_user, process_payment_success, _daily_check
 
 SUCCESS_CMD = "success1467"
 REFUSED_CMD = "refused1467"
+NOTIFY_CMD = "notify1467"
 
 async def cmd_success(message: types.Message):
     if not message.text.startswith(f"/{SUCCESS_CMD}"):
@@ -23,6 +24,14 @@ async def cmd_refused(message: types.Message):
     await message.answer("Оплата отменена.")
 
 
+async def cmd_notify(message: types.Message):
+    if not message.text.startswith(f"/{NOTIFY_CMD}"):
+        return
+    await _daily_check(message.bot)
+    await message.answer("Уведомления отправлены")
+
+
 def register(dp: Dispatcher):
     dp.message.register(cmd_success, Command(SUCCESS_CMD))
     dp.message.register(cmd_refused, Command(REFUSED_CMD))
+    dp.message.register(cmd_notify, Command(NOTIFY_CMD))


### PR DESCRIPTION
## Summary
- add `/notify1467` command to trigger subscription reminders
- document the new command in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68583271d390832eb1abece819d9bf95