### PR TITLE
Improve subscription and request handling

### DIFF
--- a/bot/handlers/photo.py
+++ b/bot/handlers/photo.py
@@ -6,8 +6,8 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 
 from ..services import analyze_photo, analyze_photo_with_hint
 from ..utils import format_meal_message, parse_serving, to_float
-from ..keyboards import meal_actions_kb, back_menu_kb
-from ..subscriptions import consume_request, ensure_user, FREE_LIMIT, PAID_LIMIT
+from ..keyboards import meal_actions_kb, back_menu_kb, pay_kb
+from ..subscriptions import consume_request, ensure_user, has_request_quota, FREE_LIMIT, PAID_LIMIT
 from ..database import SessionLocal
 from ..states import EditMeal
 from ..storage import pending_meals
@@ -15,9 +15,12 @@ from ..storage import pending_meals
 async def request_photo(message: types.Message):
     session = SessionLocal()
     user = ensure_user(session, message.from_user.id)
-    if not consume_request(session, user):
-        reset = user.period_start + timedelta(days=30)
-        await message.answer(f"Твои бесплатные запросы обновятся {reset.date()}, но ты можешь перейти на безлимитную подписку", reply_markup=back_menu_kb())
+    if not has_request_quota(session, user):
+        reset = user.period_end.date() if user.period_end else (user.period_start + timedelta(days=30)).date()
+        await message.answer(
+            f"Твои бесплатные запросы обновятся {reset}, но ты можешь перейти на безлимитную подписку",
+            reply_markup=pay_kb(),
+        )
         session.close()
         return
     session.close()
@@ -34,10 +37,10 @@ async def handle_photo(message: types.Message, state: FSMContext):
     session = SessionLocal()
     user = ensure_user(session, message.from_user.id)
     if not consume_request(session, user):
-        reset = user.period_start + timedelta(days=30)
+        reset = user.period_end.date() if user.period_end else (user.period_start + timedelta(days=30)).date()
         await message.answer(
-            f"Твои бесплатные запросы обновятся {reset.date()}, но ты можешь перейти на безлимитную подписку",
-            reply_markup=back_menu_kb(),
+            f"Твои бесплатные запросы обновятся {reset}, но ты можешь перейти на безлимитную подписку",
+            reply_markup=pay_kb(),
         )
         session.close()
         return

--- a/bot/handlers/subscription.py
+++ b/bot/handlers/subscription.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from aiogram import types, Dispatcher
+from aiogram import types, Dispatcher, F
 from aiogram.filters import Command
 
 from ..database import SessionLocal
@@ -8,6 +8,14 @@ from ..subscriptions import ensure_user, process_payment_success, _daily_check
 SUCCESS_CMD = "success1467"
 REFUSED_CMD = "refused1467"
 NOTIFY_CMD = "notify1467"
+
+
+async def cb_pay(query: types.CallbackQuery):
+    """Show payment instructions."""
+    await query.message.answer(
+        "Чтобы оформить подписку, используйте команду /success1467 или свяжитесь с поддержкой."
+    )
+    await query.answer()
 
 async def cmd_success(message: types.Message):
     if not message.text.startswith(f"/{SUCCESS_CMD}"):
@@ -35,3 +43,4 @@ def register(dp: Dispatcher):
     dp.message.register(cmd_success, Command(SUCCESS_CMD))
     dp.message.register(cmd_refused, Command(REFUSED_CMD))
     dp.message.register(cmd_notify, Command(NOTIFY_CMD))
+    dp.callback_query.register(cb_pay, F.data == "pay")

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -84,3 +84,11 @@ def back_menu_kb() -> ReplyKeyboardMarkup:
         keyboard=[[KeyboardButton(text="🥑 Главное меню")]],
         resize_keyboard=True,
     )
+
+
+def pay_kb() -> InlineKeyboardMarkup:
+    """Inline keyboard with a single payment button."""
+    builder = InlineKeyboardBuilder()
+    builder.button(text="Оплатить", callback_data="pay")
+    builder.adjust(1)
+    return builder.as_markup()

--- a/bot/subscriptions.py
+++ b/bot/subscriptions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from datetime import datetime, timedelta
+from calendar import monthrange
 from typing import Optional
 
 import asyncio
@@ -15,12 +16,14 @@ PAID_LIMIT = 800
 def ensure_user(session: SessionLocal, telegram_id: int) -> User:
     user = session.query(User).filter_by(telegram_id=telegram_id).first()
     if not user:
+        now = datetime.utcnow()
         user = User(
             telegram_id=telegram_id,
             grade="free",
             request_limit=FREE_LIMIT,
             requests_used=0,
-            period_start=datetime.utcnow(),
+            period_start=now,
+            period_end=now + timedelta(days=30),
         )
         session.add(user)
         session.commit()
@@ -38,14 +41,24 @@ def update_limits(user: User) -> None:
             user.request_limit = FREE_LIMIT
             user.requests_used = 0
             user.period_start = now
-            user.period_end = None
+            user.period_end = now + timedelta(days=30)
             user.notified_7d = False
             user.notified_3d = False
             user.notified_0d = False
     else:
-        if now >= user.period_start + timedelta(days=30):
+        if user.period_end is None:
+            user.period_end = user.period_start + timedelta(days=30)
+        if now >= user.period_end:
             user.period_start = now
+            user.period_end = now + timedelta(days=30)
             user.requests_used = 0
+
+
+def has_request_quota(session: SessionLocal, user: User) -> bool:
+    """Check if user has remaining GPT requests without consuming one."""
+    update_limits(user)
+    session.commit()
+    return user.requests_used < user.request_limit
 
 
 def consume_request(session: SessionLocal, user: User) -> bool:
@@ -65,10 +78,19 @@ def days_left(user: User) -> Optional[int]:
 
 def process_payment_success(session: SessionLocal, user: User):
     now = datetime.utcnow()
+
+    def add_month(dt: datetime) -> datetime:
+        month = dt.month + 1
+        year = dt.year + (month - 1) // 12
+        month = (month - 1) % 12 + 1
+        day = min(dt.day, monthrange(year, month)[1])
+        return dt.replace(year=year, month=month, day=day)
+
     if user.period_end and user.period_end > now:
-        user.period_end += timedelta(days=30)
+        user.period_end = add_month(user.period_end)
     else:
-        user.period_end = now + timedelta(days=30)
+        base = user.period_end if user.period_end else now
+        user.period_end = add_month(base)
     user.grade = "paid"
     user.request_limit = PAID_LIMIT
     user.requests_used = 0
@@ -95,7 +117,6 @@ async def _daily_check(bot: Bot):
     now = datetime.utcnow()
     users = session.query(User).all()
     for user in users:
-        update_limits(user)
         if user.grade == "paid" and user.period_end:
             days = (user.period_end.date() - now.date()).days
             text = None
@@ -116,6 +137,14 @@ async def _daily_check(bot: Bot):
                     await bot.send_message(user.telegram_id, text, reply_markup=kb)
                 except Exception:
                     pass
+        prev_end = user.period_end
+        prev_grade = user.grade
+        update_limits(user)
+        if prev_grade == "free" and prev_end and prev_end <= now < user.period_end:
+            try:
+                await bot.send_message(user.telegram_id, "Бесплатный лимит обновлён")
+            except Exception:
+                pass
     session.commit()
     session.close()
 


### PR DESCRIPTION
## Summary
- add pay button keyboard and callbacks
- update hint prompt text order
- refine request limit handling and month math
- reset free limits monthly with notifications
- add payment button to limit alerts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685847e6d434832e89f8376e775d48a6