### PR TITLE
Fix FAQ parse error

### DIFF
--- a/bot/handlers/faq.py
+++ b/bot/handlers/faq.py
@@ -6,12 +6,12 @@ FAQ_TEXT = (
     "❓ Что, как и почему?\n"
     "Мы собрали все частые вопросы в одной статье: от распознавания еды до подписки.\n\n"
     "👇 Загляни в ЧаВо — там всё просто\n"
-    f"[❓ЧаВо]({FAQ_LINK})\n\n"
+    f'<a href="{FAQ_LINK}">❓ЧаВо</a>\n\n'
     f"📬 Есть вопросы? Напишите нам: {SUPPORT_HANDLE}"
 )
 
 async def cmd_faq(message: types.Message):
-    await message.answer(FAQ_TEXT, reply_markup=back_menu_kb(), parse_mode="Markdown")
+    await message.answer(FAQ_TEXT, reply_markup=back_menu_kb(), parse_mode="HTML")
 
 
 def register(dp: Dispatcher):


### PR DESCRIPTION
## Summary
- fix FAQ message parsing by using HTML formatting

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c3700656c832ea28ea9cac23b27a4