### PR TITLE
Fix FAQ string formatting

### DIFF
--- a/bot/handlers/faq.py
+++ b/bot/handlers/faq.py
@@ -2,16 +2,18 @@ from ..settings import SUPPORT_HANDLE, FAQ_LINK
 from aiogram import types, Dispatcher, F
 from ..keyboards import back_menu_kb
 
-FAQ_TEXT = (
-    "❓ Что, как и почему?\n"
-    "Мы собрали все частые вопросы в одной статье: от распознавания еды до подписки.\n\n"
-    "👇 Загляни в ЧаВо — там всё просто\n"
-    f"[❓ЧаВо]({FAQ_LINK})\n\n"
-    f"📬 Есть вопросы? Напишите нам: {SUPPORT_HANDLE}"
-)
+FAQ_TEXT = f"""
+❓ Что, как и почему?
+Мы собрали все частые вопросы в одной статье: от распознавания еды до подписки.
+
+👇 Загляни в ЧаВо — там всё просто
+❓<a href="{FAQ_LINK}">ЧаВо</a>
+
+📬 Есть вопросы? Напишите нам: {SUPPORT_HANDLE}
+"""
 
 async def cmd_faq(message: types.Message):
-    await message.answer(FAQ_TEXT, reply_markup=back_menu_kb(), parse_mode="Markdown")
+    await message.answer(FAQ_TEXT, reply_markup=back_menu_kb(), parse_mode="HTML")
 
 
 def register(dp: Dispatcher):


### PR DESCRIPTION
## Summary
- rewrite `FAQ_TEXT` using a single triple‑quoted string

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c3700656c832ea28ea9cac23b27a4