### PR TITLE
Fix FAQ handler merge conflict

### DIFF
--- a/bot/handlers/faq.py
+++ b/bot/handlers/faq.py
@@ -2,7 +2,6 @@ from ..settings import SUPPORT_HANDLE, FAQ_LINK
 from aiogram import types, Dispatcher, F
 from ..keyboards import back_menu_kb
 
-<<<<<<< codex/fix-telegrambadrequest-in-faq-handler
 FAQ_TEXT = f"""
 ❓ Что, как и почему?
 Мы собрали все частые вопросы в одной статье: от распознавания еды до подписки.
@@ -12,19 +11,6 @@ FAQ_TEXT = f"""
 
 📬 Есть вопросы? Напишите нам: {SUPPORT_HANDLE}
 """
-=======
-FAQ_TEXT = (
-    "❓ Что, как и почему?\n"
-    "Мы собрали все частые вопросы в одной статье: от распознавания еды до подписки.\n\n"
-    "👇 Загляни в ЧаВо — там всё просто\n"
-<<<<<<< codex/fix-telegrambadrequest-in-faq-handler
-    f'❓<a href="{FAQ_LINK}">ЧаВо</a>\n\n'
-=======
-    f'<a href="{FAQ_LINK}">❓ЧаВо</a>\n\n'
->>>>>>> dev
-    f"📬 Есть вопросы? Напишите нам: {SUPPORT_HANDLE}"
-)
->>>>>>> dev
 
 async def cmd_faq(message: types.Message):
     await message.answer(FAQ_TEXT, reply_markup=back_menu_kb(), parse_mode="HTML")


### PR DESCRIPTION
## Summary
- remove merge conflict markers in `faq.py`

## Testing
- `python3 -m bot.main` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_685c3af25704832e81caa688d4d563c5