### PR TITLE
Fix free cycle notice and clarify usage count

### DIFF
--- a/bot/database.py
+++ b/bot/database.py
@@ -50,6 +50,8 @@ def _ensure_columns():
             conn.execute(text("ALTER TABLE users ADD COLUMN notified_0d BOOLEAN DEFAULT 0"))
         if "notified_1d" not in existing:
             conn.execute(text("ALTER TABLE users ADD COLUMN notified_1d BOOLEAN DEFAULT 0"))
+        if "notified_free" not in existing:
+            conn.execute(text("ALTER TABLE users ADD COLUMN notified_free BOOLEAN DEFAULT 1"))
 
 
 class User(Base):
@@ -66,6 +68,7 @@ class User(Base):
     notified_3d = Column(Boolean, default=False)
     notified_1d = Column(Boolean, default=False)
     notified_0d = Column(Boolean, default=False)
+    notified_free = Column(Boolean, default=True)
     meals = relationship('Meal', back_populates='user')
 
 class Meal(Base):

--- a/bot/handlers/callbacks.py
+++ b/bot/handlers/callbacks.py
@@ -5,10 +5,10 @@ from aiogram.filters import StateFilter
 
 from ..database import SessionLocal, User, Meal
 from ..services import analyze_photo_with_hint
-from ..subscriptions import consume_request, ensure_user
-from datetime import timedelta
+from ..subscriptions import ensure_user
+
 from ..utils import format_meal_message, parse_serving, to_float
-from ..keyboards import meal_actions_kb, save_options_kb, confirm_save_kb, main_menu_kb, pay_kb
+from ..keyboards import meal_actions_kb, save_options_kb, confirm_save_kb, main_menu_kb
 from ..states import EditMeal
 from ..storage import pending_meals
 
@@ -72,16 +72,7 @@ async def process_edit(message: types.Message, state: FSMContext):
         return
     meal = pending_meals[meal_id]
     session = SessionLocal()
-    user = ensure_user(session, message.from_user.id)
-    if not consume_request(session, user):
-        reset = user.period_end.date() if user.period_end else (user.period_start + timedelta(days=30)).date()
-        await message.answer(
-            f"Твои бесплатные запросы обновятся {reset}, но ты можешь перейти на безлимитную подписку",
-            reply_markup=pay_kb(),
-        )
-        session.close()
-        await state.clear()
-        return
+    ensure_user(session, message.from_user.id)
     session.close()
     MAX_LEN = 200
     if not message.text or len(message.text) > MAX_LEN:


### PR DESCRIPTION
## Summary
- add `notified_free` flag to track when free quota renews
- reset this flag in `update_limits` when a new free cycle starts
- send free-cycle reminder in subscription watcher using the new flag
- stop consuming request quota when user clarifies a photo

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c4774b654832eb3686032b28fceaf