### PR TITLE
Fix free renewal notifier

### DIFF
--- a/bot/database.py
+++ b/bot/database.py
@@ -51,7 +51,7 @@ def _ensure_columns():
         if "notified_1d" not in existing:
             conn.execute(text("ALTER TABLE users ADD COLUMN notified_1d BOOLEAN DEFAULT 0"))
         if "notified_free" not in existing:
-            conn.execute(text("ALTER TABLE users ADD COLUMN notified_free BOOLEAN DEFAULT 1"))
+            conn.execute(text("ALTER TABLE users ADD COLUMN notified_free BOOLEAN DEFAULT 0"))
 
 
 class User(Base):
@@ -68,7 +68,7 @@ class User(Base):
     notified_3d = Column(Boolean, default=False)
     notified_1d = Column(Boolean, default=False)
     notified_0d = Column(Boolean, default=False)
-    notified_free = Column(Boolean, default=True)
+    notified_free = Column(Boolean, default=False)
     meals = relationship('Meal', back_populates='user')
 
 class Meal(Base):

--- a/bot/subscriptions.py
+++ b/bot/subscriptions.py
@@ -26,7 +26,7 @@ def ensure_user(session: SessionLocal, telegram_id: int) -> User:
             period_start=now,
             period_end=now + timedelta(days=30),
             notified_1d=False,
-            notified_free=True,
+            notified_free=False,
         )
         session.add(user)
         session.commit()
@@ -108,14 +108,13 @@ def process_payment_success(session: SessionLocal, user: User, months: int = 1):
 
 
 def subscription_watcher(bot: Bot, check_interval: int = 3600):
+    """Check subscriptions periodically and notify users."""
+
     async def _watch():
-        last_date = None
         while True:
-            now = datetime.utcnow() + timedelta(hours=3)  # Moscow time
-            if last_date != now.date():
-                last_date = now.date()
-                await _daily_check(bot)
+            await _daily_check(bot)
             await asyncio.sleep(check_interval)
+
     return _watch
 
 


### PR DESCRIPTION
## Summary
- run subscription watcher every hour regardless of date

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c4bf3faa4832ead38007429e19590