### PR TITLE
Improve subscription handling

### DIFF
--- a/bot/handlers/subscription.py
+++ b/bot/handlers/subscription.py
@@ -87,7 +87,10 @@ async def show_subscription_menu(message: types.Message):
 
 
 async def cb_subscribe(query: types.CallbackQuery, state: FSMContext):
-    await show_subscription_menu(query.message)
+    try:
+        await query.message.edit_text(INTRO_TEXT)
+    except Exception:
+        pass
     await state.clear()
     await query.answer()
 

--- a/bot/subscriptions.py
+++ b/bot/subscriptions.py
@@ -49,7 +49,7 @@ def update_limits(user: User) -> None:
             user.notified_3d = False
             user.notified_1d = False
             user.notified_0d = False
-            user.notified_free = False
+            user.notified_free = True
     else:
         if user.period_end is None:
             user.period_end = user.period_start + timedelta(days=30)
@@ -92,11 +92,10 @@ def process_payment_success(session: SessionLocal, user: User, months: int = 1):
         day = min(dt.day, monthrange(year, month)[1])
         return dt.replace(year=year, month=month, day=day)
 
-    if user.period_end and user.period_end > now:
+    if user.grade == "paid" and user.period_end and user.period_end > now:
         user.period_end = add_month(user.period_end, months)
     else:
-        base = user.period_end if user.period_end else now
-        user.period_end = add_month(base, months)
+        user.period_end = add_month(now, months)
     user.grade = "paid"
     user.request_limit = PAID_LIMIT
     user.requests_used = 0


### PR DESCRIPTION
## Summary
- update inline callback to edit notification text when user opts to subscribe
- fix subscription renewal date logic
- do not send free quota reminder right after paid plan expires

## Testing
- `python -m py_compile bot/handlers/subscription.py bot/subscriptions.py`

------
https://chatgpt.com/codex/tasks/task_e_685c55df63e0832eb2d7c0a4b3a86f50