### PR TITLE
Fix subscription notification deletion

### DIFF
--- a/bot/handlers/subscription.py
+++ b/bot/handlers/subscription.py
@@ -146,7 +146,8 @@ async def handle_successful_payment(message: types.Message):
     user = ensure_user(session, message.from_user.id)
     process_payment_success(session, user, months)
     session.close()
-    await message.delete()
+    # Don't delete the invoice message here so Telegram can replace it
+    # with the service notification that confirms the payment.
     await message.answer(
         SUB_SUCCESS,
         reply_markup=back_menu_kb(),


### PR DESCRIPTION
## Summary
- prevent deleting the invoice message to keep Telegram's payment confirmation

## Testing
- `python -m compileall -q bot`

------
https://chatgpt.com/codex/tasks/task_e_685d2557d1a4832e8d54a2975b77cf34