### PR TITLE
Update default DB URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Telegram bot for tracking meals and calculating macros. Built with `aiogram` and
 2. Create a `.env` file with `BOT_TOKEN` (Telegram token) and optionally
    `OPENAI_API_KEY` for OpenAI integration. These values are loaded in
    `bot/config.py`. You can also set `ADMIN_COMMAND` (default `admin1467`),
-   `DATABASE_URL`, and `YOOKASSA_TOKEN` for payments here. For testing, the
+   `DATABASE_URL` (defaults to `sqlite:///bot.db`), and `YOOKASSA_TOKEN` for payments here. For testing, the
    `SUBSCRIPTION_CHECK_INTERVAL` (in seconds) controls how often subscription
    statuses are checked (default `3600`).
 
@@ -24,8 +24,8 @@ Telegram bot for tracking meals and calculating macros. Built with `aiogram` and
    python bot.py
    ```
 
-The database is stored in `bot.db` in the project root by default. You can change
-this by setting `DATABASE_URL`.
+The database is stored in `bot.db` in the project root by default (connection
+string `sqlite:///bot.db`). You can change this by setting `DATABASE_URL`.
 To use PostgreSQL instead of SQLite, install `psycopg2-binary` and set
 `DATABASE_URL` to a PostgreSQL connection string, e.g.
 `postgresql+psycopg2://user:password@host:5432/dbname`.

--- a/bot/config.py
+++ b/bot/config.py
@@ -7,7 +7,7 @@ load_dotenv()
 # Centralized configuration for tokens and database
 API_TOKEN = os.getenv("BOT_TOKEN", "YOUR_BOT_TOKEN")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "YOUR_OPENAI_API_KEY")
-DATABASE_URL = os.getenv("DATABASE_URL", "DATABASE_URL")
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///bot.db")
 ADMIN_COMMAND = os.getenv("ADMIN_COMMAND", "ADMIN_COMMAND")
 YOOKASSA_TOKEN = os.getenv("YOOKASSA_TOKEN", "YOOKASSA_TOKEN")
 SUBSCRIPTION_CHECK_INTERVAL = int(os.getenv("SUBSCRIPTION_CHECK_INTERVAL", "1800"))


### PR DESCRIPTION
## Summary
- default `DATABASE_URL` to `sqlite:///bot.db`
- document the connection string in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862e5abf6fc832e9b0437a956d766a4