### PR TITLE
Update GPT call parameters

### DIFF
--- a/bot/services.py
+++ b/bot/services.py
@@ -30,18 +30,22 @@ async def _chat(messages: List[Dict], retries: int = 3, backoff: float = 0.5) ->
             resp = await client.responses.create(
                 model=MODEL_NAME,
                 input=messages,
-                text={"format": {"type": "text"}},
+                text={"format": {"type": "json_object"}},
                 reasoning={},
-                max_output_tokens=200,
-                temperature=0.2,
                 tools=[
                     {
                         "type": "web_search_preview",
-                        "user_location": {"type": "approximate", "timezone": "Europe/Moscow"},
-                        "search_context_size": "high",
+                        "user_location": {
+                            "type": "approximate",
+                            "country": "RU",
+                            "region": "Moscow",
+                            "city": "Moscow",
+                        },
+                        "search_context_size": "medium",
                     }
                 ],
-                tool_choice="auto",
+                temperature=0.2,
+                max_output_tokens=200,
                 top_p=1,
                 store=False,
             )


### PR DESCRIPTION
## Summary
- adjust OpenAI responses API parameters to follow official example

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866cda09fe4832e98451a5bf2a7e2f0