### PR TITLE
Add inline menu navigation

### DIFF
--- a/bot/handlers/history.py
+++ b/bot/handlers/history.py
@@ -31,7 +31,7 @@ async def send_history(bot: Bot, user_id: int, chat_id: int, offset: int, header
             text_lines.append(HISTORY_DAY_HEADER.format(day=day.day, month=month))
             text_lines.append(HISTORY_NO_MEALS)
             text_lines.append("")
-        await bot.send_message(chat_id, "\n".join(text_lines), reply_markup=history_nav_kb(offset, 1))
+        await bot.send_message(chat_id, "\n".join(text_lines), reply_markup=history_nav_kb(offset, 1, include_back=True))
         session.close()
         return
     
@@ -70,14 +70,8 @@ async def send_history(bot: Bot, user_id: int, chat_id: int, offset: int, header
             ]
         )
     session.close()
-    builder = InlineKeyboardBuilder()
-    count = 1
-    builder.button(text=BTN_LEFT_HISTORY, callback_data=f"hist:{offset+1}")
-    if offset > 0:
-        builder.button(text=BTN_RIGHT_HISTORY, callback_data=f"hist:{offset-1}")
-        count += 1
-    builder.adjust(count)
-    await bot.send_message(chat_id, "\n".join(text_lines), reply_markup=builder.as_markup())
+    builder = history_nav_kb(offset, 1, include_back=True)
+    await bot.send_message(chat_id, "\n".join(text_lines), reply_markup=builder)
 
 async def cmd_history(message: types.Message):
     await send_history(

--- a/bot/handlers/start.py
+++ b/bot/handlers/start.py
@@ -1,15 +1,16 @@
-from aiogram import types, Dispatcher
+from aiogram import types, Dispatcher, F
 from aiogram.filters import Command
 
 from ..database import SessionLocal, User
 from ..subscriptions import ensure_user, days_left, update_limits
-from ..keyboards import main_menu_kb
+from ..keyboards import main_menu_kb, menu_inline_kb
 from ..texts import (
     WELCOME_BASE,
     BTN_MAIN_MENU,
     BTN_BACK,
     REMAINING_FREE,
     REMAINING_DAYS,
+    DEV_FEATURE,
 )
 
 
@@ -32,7 +33,8 @@ async def cmd_start(message: types.Message):
     text = get_welcome_text(user)
     session.commit()
     session.close()
-    await message.answer(text, reply_markup=main_menu_kb())
+    msg = await message.answer(text, reply_markup=main_menu_kb())
+    await msg.edit_reply_markup(menu_inline_kb())
 
 
 async def back_to_menu(message: types.Message):
@@ -42,7 +44,31 @@ async def back_to_menu(message: types.Message):
     text = get_welcome_text(user)
     session.commit()
     session.close()
-    await message.answer(text, reply_markup=main_menu_kb())
+    msg = await message.answer(text, reply_markup=main_menu_kb())
+    await msg.edit_reply_markup(menu_inline_kb())
+
+
+async def cb_menu(query: types.CallbackQuery):
+    session = SessionLocal()
+    user = ensure_user(session, query.from_user.id)
+    text = get_welcome_text(user)
+    session.commit()
+    session.close()
+    await query.message.edit_text(text)
+    await query.message.edit_reply_markup(menu_inline_kb())
+    await query.answer()
+
+
+async def cb_manual(query: types.CallbackQuery):
+    await query.message.edit_text(DEV_FEATURE)
+    await query.message.edit_reply_markup(menu_inline_kb())
+    await query.answer()
+
+
+async def cb_settings(query: types.CallbackQuery):
+    await query.message.edit_text(DEV_FEATURE)
+    await query.message.edit_reply_markup(menu_inline_kb())
+    await query.answer()
 
 
 def register(dp: Dispatcher):
@@ -51,3 +77,6 @@ def register(dp: Dispatcher):
         back_to_menu,
         lambda m: m.text in {BTN_MAIN_MENU, BTN_BACK},
     )
+    dp.callback_query.register(cb_menu, F.data == "menu")
+    dp.callback_query.register(cb_manual, F.data == "manual")
+    dp.callback_query.register(cb_settings, F.data == "settings")

--- a/bot/handlers/stats.py
+++ b/bot/handlers/stats.py
@@ -4,7 +4,15 @@ from aiogram.filters import Command
 
 from ..database import SessionLocal, Meal, User
 from ..utils import make_bar_chart
-from ..keyboards import stats_period_kb, main_menu_kb, stats_menu_kb
+from ..keyboards import (
+    stats_period_kb,
+    main_menu_kb,
+    stats_menu_kb,  # kept for legacy
+    stats_menu_inline_kb,
+    menu_inline_kb,
+    history_nav_kb,
+)
+from .history import send_history
 from ..texts import (
     STATS_CHOOSE_PERIOD,
     STATS_NO_DATA,
@@ -22,11 +30,18 @@ from ..texts import (
     BTN_REPORT_DAY,
     BTN_STATS,
     STATS_MENU_TEXT,
+    STATS_MENU_SHORT,
     BTN_BACK,
 )
 
 async def show_stats_menu(message: types.Message):
     await message.answer(STATS_MENU_TEXT, reply_markup=stats_menu_kb())
+
+
+async def cb_stats_menu(query: types.CallbackQuery):
+    await query.message.edit_text(STATS_MENU_SHORT)
+    await query.message.edit_reply_markup(stats_menu_inline_kb())
+    await query.answer()
 
 async def cmd_stats(message: types.Message):
     await message.answer(
@@ -68,6 +83,72 @@ async def cb_stats(query: types.CallbackQuery):
         chart=make_bar_chart(totals),
     )
     await query.message.edit_text(text)
+    await query.answer()
+
+
+async def cb_report_day(query: types.CallbackQuery):
+    session = SessionLocal()
+    user = session.query(User).filter_by(telegram_id=query.from_user.id).first()
+    if not user:
+        await query.message.edit_text(STATS_NO_DATA)
+        await query.answer()
+        session.close()
+        return
+    start = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+    end = start + timedelta(days=1)
+    meals = (
+        session.query(Meal)
+        .filter(Meal.user_id == user.id, Meal.timestamp >= start, Meal.timestamp < end)
+        .order_by(Meal.timestamp)
+        .all()
+    )
+    session.close()
+    if not meals:
+        await query.message.edit_text(REPORT_EMPTY)
+        await query.answer()
+        return
+
+    totals = {"calories": 0.0, "protein": 0.0, "fat": 0.0, "carbs": 0.0}
+    for m in meals:
+        totals["calories"] += m.calories
+        totals["protein"] += m.protein
+        totals["fat"] += m.fat
+        totals["carbs"] += m.carbs
+
+    lines = [
+        REPORT_HEADER,
+        "",
+        REPORT_TOTAL,
+        REPORT_LINE_CAL.format(cal=int(totals['calories'])),
+        REPORT_LINE_P.format(protein=int(totals['protein'])),
+        REPORT_LINE_F.format(fat=int(totals['fat'])),
+        REPORT_LINE_C.format(carbs=int(totals['carbs'])),
+        "",
+        REPORT_MEALS_TITLE,
+    ]
+
+    dishes = []
+    drinks = []
+    for meal in meals:
+        icon = '🥤' if getattr(meal, 'type', 'meal') == 'drink' else '🍜'
+        line = MEAL_LINE.format(
+            icon=icon,
+            name=meal.name,
+            protein=int(meal.protein),
+            fat=int(meal.fat),
+            carbs=int(meal.carbs),
+        )
+        if getattr(meal, 'type', 'meal') == 'drink':
+            drinks.append(line)
+        else:
+            dishes.append(line)
+
+    lines.extend(dishes)
+    if drinks:
+        lines.append("")
+        lines.extend(drinks)
+
+    await query.message.edit_text("\n".join(lines), reply_markup=stats_menu_inline_kb())
     await query.answer()
 
 
@@ -138,8 +219,23 @@ async def report_day(message: types.Message):
     await message.answer("\n".join(lines), reply_markup=main_menu_kb())
 
 
+async def cb_my_meals(query: types.CallbackQuery):
+    await query.message.delete()
+    await send_history(
+        query.bot,
+        query.from_user.id,
+        query.message.chat.id,
+        0,
+        header=True,
+    )
+    await query.answer()
+
+
 def register(dp: Dispatcher):
     dp.message.register(cmd_stats, Command('stats'))
     dp.message.register(show_stats_menu, F.text == BTN_STATS)
     dp.message.register(report_day, F.text == BTN_REPORT_DAY)
+    dp.callback_query.register(cb_stats_menu, F.data == 'stats_menu')
+    dp.callback_query.register(cb_report_day, F.data == 'report_day')
+    dp.callback_query.register(cb_my_meals, F.data == 'my_meals')
     dp.callback_query.register(cb_stats, F.data.startswith('stats:'))

--- a/bot/handlers/subscription.py
+++ b/bot/handlers/subscription.py
@@ -10,6 +10,8 @@ from ..keyboards import (
     pay_kb,
     back_menu_kb,
     payment_method_inline,
+    subscription_plans_inline_kb,
+    menu_inline_kb,
 )
 from ..config import YOOKASSA_TOKEN
 from aiogram.types import LabeledPrice
@@ -81,15 +83,12 @@ async def cb_pay(query: types.CallbackQuery):
 
 
 async def show_subscription_menu(message: types.Message):
-    await message.answer(INTRO_TEXT, reply_markup=subscription_plans_kb())
+    await message.answer(INTRO_TEXT, reply_markup=subscription_plans_inline_kb())
 
 
 async def cb_subscribe(query: types.CallbackQuery, state: FSMContext):
-    try:
-        await query.message.delete()
-    except Exception:
-        pass
-    await show_subscription_menu(query.message)
+    await query.message.edit_text(INTRO_TEXT)
+    await query.message.edit_reply_markup(subscription_plans_inline_kb())
     await state.clear()
     await query.answer()
 
@@ -105,8 +104,17 @@ async def choose_plan(message: types.Message, state: FSMContext):
     code = PLAN_CODES.get(message.text)
     await message.answer(
         PLAN_TEXT,
-        reply_markup=payment_method_inline(code),
+        reply_markup=payment_method_inline(code, include_back=True),
     )
+
+
+async def cb_plan(query: types.CallbackQuery):
+    code = query.data.split(":", 1)[1]
+    await query.message.edit_text(
+        PLAN_TEXT,
+        reply_markup=payment_method_inline(code, include_back=True),
+    )
+    await query.answer()
 
 
 async def cb_method(query: types.CallbackQuery):
@@ -115,8 +123,24 @@ async def cb_method(query: types.CallbackQuery):
     plan = PLAN_DISPLAY.get(code, "")
     await query.message.edit_text(
         SUB_METHOD_TEXT.format(plan=plan),
-        reply_markup=pay_kb(code),
+        reply_markup=pay_kb(code, include_back=True),
     )
+    await query.answer()
+
+
+async def cb_method_back(query: types.CallbackQuery):
+    parts = query.data.split(":", 1)
+    code = parts[1] if len(parts) > 1 else ""
+    await query.message.edit_text(
+        PLAN_TEXT,
+        reply_markup=payment_method_inline(code, include_back=True),
+    )
+    await query.answer()
+
+
+async def cb_sub_plans(query: types.CallbackQuery):
+    await query.message.edit_text(INTRO_TEXT)
+    await query.message.edit_reply_markup(subscription_plans_inline_kb())
     await query.answer()
 
 async def cmd_success(message: types.Message):
@@ -166,19 +190,11 @@ def register(dp: Dispatcher):
     dp.message.register(cmd_refused, Command(REFUSED_CMD))
     dp.message.register(cmd_notify, Command(NOTIFY_CMD))
     dp.message.register(show_subscription_menu, F.text == BTN_SUBSCRIPTION)
-    dp.message.register(
-        choose_plan,
-        F.text.in_(
-            {
-                BTN_PLAN_1M.format(price=PLAN_PRICES['1m']),
-                BTN_PLAN_3M.format(price=PLAN_PRICES['3m']),
-                BTN_PLAN_6M.format(price=PLAN_PRICES['6m']),
-            }
-        ),
-    )
-    dp.message.register(show_subscription_menu, F.text == BTN_BACK_TEXT)
+    dp.callback_query.register(cb_subscribe, F.data == "subscribe")
+    dp.callback_query.register(cb_plan, F.data.startswith("plan:"))
+    dp.callback_query.register(cb_sub_plans, F.data == "sub_plans")
+    dp.callback_query.register(cb_method_back, F.data.startswith("method_back:"))
     dp.callback_query.register(cb_method, F.data.startswith("method:"))
     dp.callback_query.register(cb_pay, F.data.startswith("pay"))
     dp.pre_checkout_query.register(handle_pre_checkout)
     dp.message.register(handle_successful_payment, F.successful_payment)
-    dp.callback_query.register(cb_subscribe, F.data == "subscribe")

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -29,6 +29,8 @@ from .texts import (
     BTN_PLAN_1M,
     BTN_PLAN_3M,
     BTN_PLAN_6M,
+    BTN_MANUAL,
+    BTN_SETTINGS,
 )
 from typing import Optional
 from aiogram.utils.keyboard import InlineKeyboardBuilder
@@ -69,17 +71,20 @@ def confirm_save_kb(meal_id: str) -> InlineKeyboardMarkup:
     return builder.as_markup()
 
 
-def history_nav_kb(offset: int, total: int) -> InlineKeyboardMarkup:
+def history_nav_kb(offset: int, total: int, include_back: bool = False) -> InlineKeyboardMarkup:
     builder = InlineKeyboardBuilder()
     count = 0
     if offset > 0:
-        builder.button(text=BTN_LEFT_HISTORY, callback_data=f"hist:{offset-1}")
+        builder.button(text=BTN_LEFT_HISTORY, callback_data=f"hist:{offset+1}")
         count += 1
     if offset < total - 1:
-        builder.button(text=BTN_RIGHT_HISTORY, callback_data=f"hist:{offset+1}")
+        builder.button(text=BTN_RIGHT_HISTORY, callback_data=f"hist:{offset-1}")
         count += 1
     if count:
         builder.adjust(count)
+    if include_back:
+        builder.button(text=BTN_BACK, callback_data="stats_menu")
+        builder.adjust(1)
     return builder.as_markup()
 
 
@@ -105,11 +110,10 @@ def stats_menu_kb() -> ReplyKeyboardMarkup:
 
 
 def main_menu_kb() -> ReplyKeyboardMarkup:
-    """Main menu with four actions arranged vertically."""
+    """Persistent menu with two buttons."""
     return ReplyKeyboardMarkup(
         keyboard=[
-            [KeyboardButton(text=BTN_STATS)],
-            [KeyboardButton(text=BTN_SUBSCRIPTION)],
+            [KeyboardButton(text=BTN_MAIN_MENU)],
             [KeyboardButton(text=BTN_FAQ)],
         ],
         resize_keyboard=True,
@@ -117,22 +121,17 @@ def main_menu_kb() -> ReplyKeyboardMarkup:
 
 
 def back_menu_kb() -> ReplyKeyboardMarkup:
-    """Keyboard with a single button to return to the main menu."""
-    return ReplyKeyboardMarkup(
-        keyboard=[[KeyboardButton(text=BTN_MAIN_MENU)]],
-        resize_keyboard=True,
-    )
+    """Same as main_menu_kb for backward compatibility."""
+    return main_menu_kb()
 
 
-def pay_kb(code: Optional[str] = None) -> InlineKeyboardMarkup:
-    """Inline keyboard with a single payment button.
-
-    Optionally encodes the selected plan in callback data so invoice
-    handlers can determine which subscription to bill for.
-    """
+def pay_kb(code: Optional[str] = None, include_back: bool = False) -> InlineKeyboardMarkup:
+    """Inline keyboard with a payment button and optional back."""
     builder = InlineKeyboardBuilder()
     cb = f"pay:{code}" if code else "pay"
     builder.button(text=BTN_PAY, callback_data=cb)
+    if include_back:
+        builder.button(text=BTN_BACK, callback_data=f"method_back:{code}")
     builder.adjust(1)
     return builder.as_markup()
 
@@ -160,10 +159,12 @@ def payment_methods_kb() -> ReplyKeyboardMarkup:
     )
 
 
-def payment_method_inline(code: str) -> InlineKeyboardMarkup:
-    """Inline keyboard with a single payment method button."""
+def payment_method_inline(code: str, include_back: bool = False) -> InlineKeyboardMarkup:
+    """Inline keyboard with a payment method and optional back button."""
     builder = InlineKeyboardBuilder()
     builder.button(text=BTN_BANK_CARD, callback_data=f"method:{code}")
+    if include_back:
+        builder.button(text=BTN_BACK, callback_data="sub_plans")
     builder.adjust(1)
     return builder.as_markup()
 
@@ -172,5 +173,35 @@ def subscribe_button(text: str) -> InlineKeyboardMarkup:
     """Inline keyboard leading to the subscription menu."""
     builder = InlineKeyboardBuilder()
     builder.button(text=text, callback_data="subscribe")
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+def menu_inline_kb() -> InlineKeyboardMarkup:
+    """Main inline menu under the welcome message."""
+    builder = InlineKeyboardBuilder()
+    builder.button(text=BTN_MANUAL, callback_data="manual")
+    builder.button(text=BTN_STATS, callback_data="stats_menu")
+    builder.button(text=BTN_SUBSCRIPTION, callback_data="subscribe")
+    builder.button(text=BTN_SETTINGS, callback_data="settings")
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+def stats_menu_inline_kb() -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.button(text=BTN_REPORT_DAY, callback_data="report_day")
+    builder.button(text=BTN_MY_MEALS, callback_data="my_meals")
+    builder.button(text=BTN_BACK, callback_data="menu")
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+def subscription_plans_inline_kb() -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.button(text=BTN_PLAN_1M.format(price=PLAN_PRICES['1m']), callback_data="plan:1m")
+    builder.button(text=BTN_PLAN_3M.format(price=PLAN_PRICES['3m']), callback_data="plan:3m")
+    builder.button(text=BTN_PLAN_6M.format(price=PLAN_PRICES['6m']), callback_data="plan:6m")
+    builder.button(text=BTN_BACK, callback_data="menu")
     builder.adjust(1)
     return builder.as_markup()

--- a/bot/texts.py
+++ b/bot/texts.py
@@ -102,11 +102,16 @@ BTN_MY_MEALS = "📊 Мои приёмы"
 BTN_STATS = "📈 Статистика"
 BTN_SUBSCRIPTION = "⚡ Подписка"
 BTN_FAQ = "❓ ЧаВО"
-BTN_MAIN_MENU = "🥑 Главное меню"
+BTN_MAIN_MENU = "Меню"
 BTN_PAY = "Оплатить"
 BTN_BACK_TEXT = "🔙 Назад"
 BTN_BANK_CARD = "💳 Банковская карта"
 BTN_BROADCAST = "Рассылка"
+BTN_MANUAL = "Отправить вручную"
+BTN_SETTINGS = "Настройки"
+
+DEV_FEATURE = "Функционал в разработке"
+STATS_MENU_SHORT = "Выберите раздел:"
 
 # Portion prefixes used when saving partial servings
 PREFIX_FULL = ""


### PR DESCRIPTION
## Summary
- restructure start menu to use inline buttons
- add callbacks for manual entry, settings, and stats navigation
- support inline subscription flow with back buttons
- keep reply keyboard with permanent Menu/FAQ

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6866d5f6a054832e8022e367634fe589