### PR TITLE
Fix migrations for PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,11 @@ The bot relies on OpenAI's `gpt-4o` model for food recognition.
 The database is stored in `bot.db` in the project root by default (connection
 string `sqlite:///bot.db`). You can change this by setting `DATABASE_URL`.
 To use PostgreSQL instead of SQLite, install `psycopg2-binary` and set
+
 `DATABASE_URL` to a PostgreSQL connection string, e.g.
 `postgresql+psycopg2://user:password@host:5432/dbname`.
+The bot automatically adds any missing columns on startup,
+so upgrades work without manual migrations on both SQLite and PostgreSQL.
 
 
 ### Logging

--- a/bot/database.py
+++ b/bot/database.py
@@ -33,9 +33,8 @@ def _column_names(table: str) -> set[str]:
 
 def _ensure_columns():
     """Add new columns to old databases if they are missing."""
-    if engine.dialect.name != "sqlite":
-        return
     existing = _column_names("users")
+    dt_type = "DATETIME" if engine.dialect.name == "sqlite" else "TIMESTAMP"
     with engine.begin() as conn:
         if "grade" not in existing:
             conn.execute(text("ALTER TABLE users ADD COLUMN grade TEXT DEFAULT 'free'"))
@@ -44,10 +43,10 @@ def _ensure_columns():
         if "requests_used" not in existing:
             conn.execute(text("ALTER TABLE users ADD COLUMN requests_used INTEGER DEFAULT 0"))
         if "period_start" not in existing:
-            conn.execute(text("ALTER TABLE users ADD COLUMN period_start DATETIME DEFAULT CURRENT_TIMESTAMP"))
+            conn.execute(text(f"ALTER TABLE users ADD COLUMN period_start {dt_type} DEFAULT CURRENT_TIMESTAMP"))
         conn.execute(text("UPDATE users SET period_start=CURRENT_TIMESTAMP WHERE period_start IS NULL"))
         if "period_end" not in existing:
-            conn.execute(text("ALTER TABLE users ADD COLUMN period_end DATETIME"))
+            conn.execute(text(f"ALTER TABLE users ADD COLUMN period_end {dt_type}"))
         if "notified_7d" not in existing:
             conn.execute(text("ALTER TABLE users ADD COLUMN notified_7d BOOLEAN DEFAULT 0"))
         if "notified_3d" not in existing:
@@ -61,7 +60,7 @@ def _ensure_columns():
         if "daily_used" not in existing:
             conn.execute(text("ALTER TABLE users ADD COLUMN daily_used INTEGER DEFAULT 0"))
         if "daily_start" not in existing:
-            conn.execute(text("ALTER TABLE users ADD COLUMN daily_start DATETIME DEFAULT CURRENT_TIMESTAMP"))
+            conn.execute(text(f"ALTER TABLE users ADD COLUMN daily_start {dt_type} DEFAULT CURRENT_TIMESTAMP"))
 
     existing = _column_names("meals")
     with engine.begin() as conn:


### PR DESCRIPTION
## Summary
- add automatic column updates for PostgreSQL
- clarify in README that missing columns are added on startup for both SQLite and PostgreSQL

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68695b158df8832e84c4bb0a9c1c5f9e