### PR TITLE
Add log timestamp prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ To use PostgreSQL instead of SQLite, install `psycopg2-binary` and set
 ### Logging
 
 Log files are written to `logs/bot.log` by default (configurable via `LOG_DIR`).
-The handler rotates daily and keeps the three most recent log files.
+Each entry starts with the timestamp `YYYY-MM-DD HH:MM:SS`. The handler rotates
+daily and keeps the three most recent log files.
 
 ### Manual database access
 

--- a/bot/main.py
+++ b/bot/main.py
@@ -47,6 +47,8 @@ if __name__ == '__main__':
     )
     logging.basicConfig(
         level=logging.INFO,
+        format="%(asctime)s %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
         handlers=[file_handler, logging.StreamHandler()]
     )
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- add timestamp format to logging configuration
- document log timestamp format

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68695b5ca0e4832e8739de91f535217b