### PR TITLE
Ignore failed hints

### DIFF
--- a/bot/handlers/callbacks.py
+++ b/bot/handlers/callbacks.py
@@ -95,7 +95,6 @@ async def process_edit(message: types.Message, state: FSMContext):
         meal['error_msg'] = err.message_id
         meal.setdefault('clarifications', 0)
         meal['clarifications'] += 1
-        meal['hints'].append(message.text)
         return
     serving = parse_serving(result.get('serving', meal['serving']))
     macros = {


### PR DESCRIPTION
## Summary
- store hints only when refinement succeeds

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68695eda4310832ea583d6dac90db62b