### PR TITLE
Fix hint handling and avoid downscaling photos

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ Log files are written to `logs/bot.log` by default (configurable via `LOG_DIR`).
 Each entry starts with the timestamp `YYYY-MM-DD HH:MM:SS`. The handler rotates
 daily and keeps the three most recent log files.
 
+### Prompt sandbox
+
+To quickly test how the recognition prompts behave, run the helper script:
+
+```bash
+python scripts/prompt_sandbox.py path/to/photo.jpg
+python scripts/prompt_sandbox.py "описание блюда" --text
+```
+
+Add `--hint "ваше уточнение"` to simulate clarification requests. The script
+prints the JSON response from the OpenAI API.
+
 ### Manual database access
 
 The default SQLite database can be inspected and edited directly. Install the

--- a/bot/handlers/callbacks.py
+++ b/bot/handlers/callbacks.py
@@ -95,7 +95,6 @@ async def process_edit(message: types.Message, state: FSMContext):
         meal['error_msg'] = err.message_id
         meal.setdefault('clarifications', 0)
         meal['clarifications'] += 1
-        meal['hints'].append(message.text)
         return
     serving = parse_serving(result.get('serving', meal['serving']))
     macros = {

--- a/bot/handlers/photo.py
+++ b/bot/handlers/photo.py
@@ -65,11 +65,12 @@ async def handle_photo(message: types.Message, state: FSMContext):
     with tempfile.NamedTemporaryFile(prefix="diet_photo_", delete=False) as tmp:
         await message.bot.download(photo.file_id, destination=tmp.name)
         photo_path = tmp.name
+    # Use the original resolution without downscaling to improve recognition
+    # consistency. Only convert to JPEG to match the API requirements.
     try:
         from PIL import Image
         img = Image.open(photo_path)
-        img.thumbnail((300, 300))
-        img.save(photo_path, format="JPEG")
+        img.save(photo_path, format="JPEG", quality=95)
     except Exception:
         pass
     result = await analyze_photo(photo_path)

--- a/scripts/prompt_sandbox.py
+++ b/scripts/prompt_sandbox.py
@@ -1,0 +1,37 @@
+import argparse
+import asyncio
+import os
+import json
+
+from bot.services import analyze_photo, analyze_photo_with_hint, analyze_text, analyze_text_with_hint
+
+
+def print_json(data):
+    print(json.dumps(data, ensure_ascii=False, indent=2))
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="Test analysis prompts")
+    parser.add_argument("source", help="Photo path or text to analyze")
+    parser.add_argument("--hint", help="Clarification text", default=None)
+    parser.add_argument("--text", action="store_true", help="Treat source as text instead of photo")
+    args = parser.parse_args()
+
+    if args.text:
+        if args.hint:
+            result = await analyze_text_with_hint(args.source, args.hint, {})
+        else:
+            result = await analyze_text(args.source)
+    else:
+        if not os.path.exists(args.source):
+            parser.error(f"File not found: {args.source}")
+        if args.hint:
+            result = await analyze_photo_with_hint(args.source, args.hint, {})
+        else:
+            result = await analyze_photo(args.source)
+
+    print_json(result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add `prompt_sandbox.py` script to try prompts and hints
- document the sandbox helper in the README
- store hints only on successful clarification
- keep the original photo resolution when sending to GPT

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68695eda4310832ea583d6dac90db62b