### PR TITLE
Fix empty user input causing 400 error

### DIFF
--- a/bot/services.py
+++ b/bot/services.py
@@ -261,6 +261,7 @@ async def analyze_text_with_hint(
     )
     content = await _chat([
         {"role": "system", "content": prompt},
+        {"role": "user", "content": description},
     ])
     if content in {"__RATE_LIMIT__", "__BAD_REQUEST__", "__ERROR__"}:
         return {"error": content.strip("_").lower()}


### PR DESCRIPTION
## Summary
- ensure a user message is included when clarifying text descriptions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686973891934832ebe9d4e914b32205a