### PR TITLE
Fix hint numbering in clarification prompts

### DIFF
--- a/bot/services.py
+++ b/bot/services.py
@@ -241,7 +241,7 @@ async def analyze_text_with_hint(
     prev_json = json.dumps(prev or {}, ensure_ascii=False)
     hints_text = ""
     if hints:
-        joined = "\n".join(f"{i+1}) {h}" for i, h in enumerate(hints, 1))
+        joined = "\n".join(f"{i}) {h}" for i, h in enumerate(hints, start=1))
         hints_text = f"Предыдущие уточнения:\n{joined}\n"
     prompt = (
         "Ты — профессиональный диетолог/нутрициолог. Ранее ты проанализировал текст и вернул такой JSON:\n"
@@ -311,7 +311,7 @@ async def analyze_photo_with_hint(
     prev_json = json.dumps(prev or {}, ensure_ascii=False)
     hints_text = ""
     if hints:
-        joined = "\n".join(f"{i+1}) {h}" for i, h in enumerate(hints, 1))
+        joined = "\n".join(f"{i}) {h}" for i, h in enumerate(hints, start=1))
         hints_text = f"Предыдущие уточнения:\n{joined}\n"
     prompt = (
         "Ты — профессиональный диетолог/нутрициолог. Ранее ты проанализировал изображение и вернул такой JSON:\n"


### PR DESCRIPTION
## Summary
- ensure clarification hints are numbered correctly

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686976ced5dc832e95924f8a7bdb54de