### PR TITLE
Improve hint formatting helper

### DIFF
--- a/bot/services.py
+++ b/bot/services.py
@@ -48,6 +48,14 @@ def _prepare_input(messages: List[Dict]) -> (Optional[str], List[Dict]):
     return instructions, input_items
 
 
+def _format_hints(hints: Optional[List[str]]) -> str:
+    """Format clarification hints as a numbered list."""
+    if not hints:
+        return ""
+    joined = "\n".join(f"{i}) {h}" for i, h in enumerate(hints, start=1))
+    return f"Предыдущие уточнения:\n{joined}\n"
+
+
 async def _chat(messages: List[Dict], retries: int = 3, backoff: float = 0.5) -> str:
     if not client.api_key:
         return ""
@@ -239,10 +247,7 @@ async def analyze_text_with_hint(
             "carbs": 30,
         }
     prev_json = json.dumps(prev or {}, ensure_ascii=False)
-    hints_text = ""
-    if hints:
-        joined = "\n".join(f"{i+1}) {h}" for i, h in enumerate(hints, 1))
-        hints_text = f"Предыдущие уточнения:\n{joined}\n"
+    hints_text = _format_hints(hints)
     prompt = (
         "Ты — профессиональный диетолог/нутрициолог. Ранее ты проанализировал текст и вернул такой JSON:\n"
         f"{prev_json}\n"
@@ -309,10 +314,7 @@ async def analyze_photo_with_hint(
     with open(photo_path, "rb") as f:
         b64 = base64.b64encode(f.read()).decode()
     prev_json = json.dumps(prev or {}, ensure_ascii=False)
-    hints_text = ""
-    if hints:
-        joined = "\n".join(f"{i+1}) {h}" for i, h in enumerate(hints, 1))
-        hints_text = f"Предыдущие уточнения:\n{joined}\n"
+    hints_text = _format_hints(hints)
     prompt = (
         "Ты — профессиональный диетолог/нутрициолог. Ранее ты проанализировал изображение и вернул такой JSON:\n"
         f"{prev_json}\n"

--- a/tests/test_hints.py
+++ b/tests/test_hints.py
@@ -1,0 +1,17 @@
+import unittest
+from bot import services
+
+class HintFormattingTest(unittest.TestCase):
+    def test_format_hints_empty(self):
+        self.assertEqual(services._format_hints([]), "")
+
+    def test_format_hints_single(self):
+        expected = "Предыдущие уточнения:\n1) hint1\n"
+        self.assertEqual(services._format_hints(["hint1"]), expected)
+
+    def test_format_hints_multiple(self):
+        expected = "Предыдущие уточнения:\n1) one\n2) two\n"
+        self.assertEqual(services._format_hints(["one", "two"]), expected)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `_format_hints` helper for proper numbering
- use helper in text/photo clarification functions
- add unit tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `PYTHONPATH=. python -m unittest discover -v tests`

------
https://chatgpt.com/codex/tasks/task_e_686976ced5dc832e95924f8a7bdb54de