### PR TITLE
Fix refine button callback

### DIFF
--- a/bot/handlers/callbacks.py
+++ b/bot/handlers/callbacks.py
@@ -12,6 +12,7 @@ from ..keyboards import (
     save_options_kb,
     confirm_save_kb,
     main_menu_kb,
+    refine_back_kb,
 )
 from ..states import EditMeal
 from ..storage import pending_meals


### PR DESCRIPTION
## Summary
- import `refine_back_kb` in callbacks handler so the refine button works

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686eb91d602c832ebcac5343a81a1c5f