### PR TITLE
Fix history button alignment

### DIFF
--- a/bot/handlers/callbacks.py
+++ b/bot/handlers/callbacks.py
@@ -12,6 +12,7 @@ from ..keyboards import (
     save_options_kb,
     confirm_save_kb,
     main_menu_kb,
+    refine_back_kb,
 )
 from ..states import EditMeal
 from ..storage import pending_meals

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -85,11 +85,13 @@ def history_nav_kb(offset: int, include_back: bool = False) -> InlineKeyboardMar
     builder.button(text=BTN_LEFT_HISTORY, callback_data=f"hist:{offset+1}")
     if offset > 0:
         builder.button(text=BTN_RIGHT_HISTORY, callback_data=f"hist:{offset-1}")
-    count = 2 if offset > 0 else 1
-    builder.adjust(count)
     if include_back:
         builder.button(text=BTN_BACK, callback_data="stats_menu")
-        builder.adjust(1)
+    count = 2 if offset > 0 else 1
+    if include_back:
+        builder.adjust(count, 1)
+    else:
+        builder.adjust(count)
     return builder.as_markup()
 
 


### PR DESCRIPTION
## Summary
- adjust history navigation keyboard so the back button is on its own row

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686eb91d602c832ebcac5343a81a1c5f