### PR TITLE
Fix context usage for hints

### DIFF
--- a/bot/handlers/callbacks.py
+++ b/bot/handlers/callbacks.py
@@ -81,13 +81,14 @@ async def process_edit(message: types.Message, state: FSMContext):
         )
         return
 
+    prev_json = meal.get('initial_json', meal)
     if meal.get('photo_path'):
         result = await analyze_photo_with_hint(
-            meal['photo_path'], message.text, meal, grade
+            meal['photo_path'], message.text, prev_json, grade
         )
     else:
         result = await analyze_text_with_hint(
-            meal.get('text', ''), message.text, meal, grade
+            meal.get('text', ''), message.text, prev_json, grade
         )
     log("prompt", "clarification analyzed for %s", message.from_user.id)
     if result.get('error') or (

--- a/bot/handlers/manual.py
+++ b/bot/handlers/manual.py
@@ -100,6 +100,7 @@ async def process_manual(message: types.Message, state: FSMContext):
         "orig_serving": serving,
         "macros": macros,
         "orig_macros": macros.copy(),
+        "initial_json": result,
         "text": message.text,
         "chat_id": message.chat.id,
         "message_id": None,

--- a/bot/handlers/photo.py
+++ b/bot/handlers/photo.py
@@ -139,6 +139,7 @@ async def handle_photo(message: types.Message, state: FSMContext):
         "orig_serving": serving,
         "macros": macros,
         "orig_macros": macros.copy(),
+        "initial_json": result,
         "photo_path": photo_path,
         "chat_id": message.chat.id,
         "message_id": None,


### PR DESCRIPTION
## Summary
- store initial analysis JSON for each meal
- use the original JSON when processing hint clarifications

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686ec0678688832e8b05b7db0df96f43