### PR TITLE
Remove previous JSON from hint context

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ manually to tweak recognition behavior.
 
 The hint prompts use placeholders:
 
-- `{context}` — previous JSON response if available.
+- `{context}` — the photo or text from the initial request.
 - `{hint}` — the latest user clarification.
 
 These placeholders are filled automatically when the bot calls the OpenAI API.

--- a/bot/handlers/callbacks.py
+++ b/bot/handlers/callbacks.py
@@ -83,11 +83,11 @@ async def process_edit(message: types.Message, state: FSMContext):
 
     if meal.get('photo_path'):
         result = await analyze_photo_with_hint(
-            meal['photo_path'], message.text, meal, grade
+            meal['photo_path'], message.text, grade
         )
     else:
         result = await analyze_text_with_hint(
-            meal.get('text', ''), message.text, meal, grade
+            meal.get('text', ''), message.text, grade
         )
     log("prompt", "clarification analyzed for %s", message.from_user.id)
     if result.get('error') or (

--- a/bot/services.py
+++ b/bot/services.py
@@ -301,10 +301,9 @@ async def analyze_text(description: str, grade: str = "pro") -> Dict[str, Any]:
 async def analyze_text_with_hint(
     description: str,
     hint: str,
-    prev: Optional[Dict[str, Any]] = None,
     grade: str = "pro",
 ) -> Dict[str, Any]:
-    """Clarify text description with additional hint."""
+    """Clarify text description with additional hint using the original text."""
     if not client.api_key:
         return {
             "success": True,
@@ -316,10 +315,7 @@ async def analyze_text_with_hint(
             "fat": 10,
             "carbs": 30,
         }
-    if prev:
-        context = f"Ранее ты проанализировал текст и вернул такой JSON:\n{json.dumps(prev, ensure_ascii=False)}"
-    else:
-        context = "Предыдущего JSON нет."
+    context = f"Текст из первого запроса: {description}"
     base = PRO_HINT_PROMPT_BASE if grade == "pro" else FREE_HINT_PROMPT_BASE
     prompt = base.format(
         context=context,
@@ -359,7 +355,6 @@ async def analyze_text_with_hint(
 async def analyze_photo_with_hint(
     photo_path: str,
     hint: str,
-    prev: Optional[Dict[str, Any]] = None,
     grade: str = "pro",
 ) -> Dict[str, Any]:
     """Re-analyze a photo using user clarification about the dish or beverage."""
@@ -377,10 +372,7 @@ async def analyze_photo_with_hint(
         }
     with open(photo_path, "rb") as f:
         b64 = base64.b64encode(f.read()).decode()
-    if prev:
-        context = f"Ранее ты проанализировал изображение и вернул такой JSON:\n{json.dumps(prev, ensure_ascii=False)}"
-    else:
-        context = "Предыдущего JSON нет."
+    context = "Фото из первого запроса"
     base = PRO_HINT_PROMPT_BASE if grade == "pro" else FREE_HINT_PROMPT_BASE
     prompt = base.format(
         context=context,


### PR DESCRIPTION
## Summary
- drop `initial_json` tracking
- send original photo or text when clarifying
- update README about hint placeholders

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686ec0678688832e8b05b7db0df96f43