### PR TITLE
Update subscription trial handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ sqlite3 bot.db
 
 Within the shell you can list tables with `.tables`, show table schemas with
 `.schema users`, `.schema meals` or `.schema payments` and execute regular SQL
-statements. For example, granting a user paid status:
+statements. For example, granting a user light status:
 
 ```sql
-UPDATE users SET grade='paid' WHERE telegram_id = 12345;
+UPDATE users SET grade='light' WHERE telegram_id = 12345;
 ```
 
 Exit the shell with `.quit` once your changes are complete. If you configured a
@@ -103,7 +103,7 @@ different `DATABASE_URL`, open that file instead.
 Two helper commands imitate payment results:
 
 ```
-/success1467  # activate or extend paid plan
+/success1467  # activate or extend light plan
 /refused1467  # simulate payment refusal
 /notify1467  # force sending pending subscription reminders
 ```

--- a/bot/database.py
+++ b/bot/database.py
@@ -40,6 +40,8 @@ def _ensure_columns():
     with engine.begin() as conn:
         if "grade" not in existing:
             conn.execute(text("ALTER TABLE users ADD COLUMN grade TEXT DEFAULT 'free'"))
+        else:
+            conn.execute(text("UPDATE users SET grade='light' WHERE grade='paid'"))
         if "request_limit" not in existing:
             conn.execute(text("ALTER TABLE users ADD COLUMN request_limit INTEGER DEFAULT 20"))
         if "requests_used" not in existing:
@@ -69,6 +71,12 @@ def _ensure_columns():
             conn.execute(text(f"ALTER TABLE users ADD COLUMN trial BOOLEAN DEFAULT {bool_default}"))
         if "trial_used" not in existing:
             conn.execute(text(f"ALTER TABLE users ADD COLUMN trial_used BOOLEAN DEFAULT {bool_default}"))
+        if "trial_end" not in existing:
+            conn.execute(text(f"ALTER TABLE users ADD COLUMN trial_end {dt_type}"))
+        if "resume_grade" not in existing:
+            conn.execute(text("ALTER TABLE users ADD COLUMN resume_grade TEXT"))
+        if "resume_period_end" not in existing:
+            conn.execute(text(f"ALTER TABLE users ADD COLUMN resume_period_end {dt_type}"))
 
     existing = _column_names("meals")
     with engine.begin() as conn:
@@ -81,11 +89,14 @@ class User(Base):
     id = Column(Integer, primary_key=True)
     telegram_id = Column(BigInteger, unique=True, index=True)
     created_at = Column(DateTime, default=datetime.utcnow)
-    grade = Column(String, default='free')  # 'free', 'paid' or 'pro'
+    grade = Column(String, default='free')  # 'free', 'light', 'pro', etc.
     request_limit = Column(Integer, default=20)
     requests_used = Column(Integer, default=0)
     period_start = Column(DateTime, default=datetime.utcnow)
     period_end = Column(DateTime, nullable=True)
+    trial_end = Column(DateTime, nullable=True)
+    resume_grade = Column(String, nullable=True)
+    resume_period_end = Column(DateTime, nullable=True)
     notified_7d = Column(Boolean, default=False)
     notified_3d = Column(Boolean, default=False)
     notified_1d = Column(Boolean, default=False)

--- a/bot/handlers/admin.py
+++ b/bot/handlers/admin.py
@@ -190,7 +190,7 @@ async def admin_stats(query: types.CallbackQuery):
     session = SessionLocal()
     now = datetime.utcnow()
     total = session.query(User).count()
-    paid = session.query(User).filter(User.grade == "paid", User.period_end > now).count()
+    paid = session.query(User).filter(User.grade == "light", User.period_end > now).count()
     pro = session.query(User).filter(User.grade == "pro", User.period_end > now).count()
     used = session.query(User).filter(User.grade == "free", User.requests_used > 0).count()
     session.close()
@@ -239,7 +239,7 @@ async def process_days(message: types.Message, state: FSMContext):
         return
     session = SessionLocal()
     user = session.query(User).filter_by(telegram_id=int(target)).first()
-    if user and user.grade in {"paid", "pro"}:
+    if user and user.grade in {"light", "pro"} and not user.trial:
         from ..subscriptions import add_subscription_days
 
         add_subscription_days(session, user, days)
@@ -261,7 +261,7 @@ async def process_days_all(message: types.Message, state: FSMContext):
 
     users = (
         session.query(User)
-        .filter(User.grade.in_(["paid", "pro"]))
+        .filter(User.grade.in_(["light", "pro"]))
         .all()
     )
     for u in users:

--- a/bot/services.py
+++ b/bot/services.py
@@ -210,7 +210,7 @@ async def analyze_photo(photo_path: str, grade: str = "pro") -> Dict[str, Any]:
         }
     with open(photo_path, "rb") as f:
         b64 = base64.b64encode(f.read()).decode()
-    prompt = PRO_PHOTO_PROMPT if grade == "pro" else FREE_PHOTO_PROMPT
+    prompt = PRO_PHOTO_PROMPT if grade.startswith("pro") or grade.startswith("light") else FREE_PHOTO_PROMPT
     # The Completions API does not support images, so we always use
     # the Responses API for photo analysis regardless of user tier.
     sender = _chat
@@ -266,8 +266,8 @@ async def analyze_text(description: str, grade: str = "pro") -> Dict[str, Any]:
             "fat": 10,
             "carbs": 30,
         }
-    prompt = PRO_TEXT_PROMPT if grade == "pro" else FREE_TEXT_PROMPT
-    sender = _chat if grade == "pro" else _completion
+    prompt = PRO_TEXT_PROMPT if grade.startswith("pro") or grade.startswith("light") else FREE_TEXT_PROMPT
+    sender = _chat if grade.startswith("pro") or grade.startswith("light") else _completion
     content = await sender(
         [
             {"role": "system", "content": prompt},
@@ -316,12 +316,12 @@ async def analyze_text_with_hint(
             "carbs": 30,
         }
     context = f"Текст из первого запроса: {description}"
-    base = PRO_HINT_PROMPT_BASE if grade == "pro" else FREE_HINT_PROMPT_BASE
+    base = PRO_HINT_PROMPT_BASE if grade.startswith("pro") or grade.startswith("light") else FREE_HINT_PROMPT_BASE
     prompt = base.format(
         context=context,
         hint=hint,
     )
-    sender = _chat if grade == "pro" else _completion
+    sender = _chat if grade.startswith("pro") or grade.startswith("light") else _completion
     content = await sender(
         [
             {"role": "system", "content": prompt},
@@ -373,7 +373,7 @@ async def analyze_photo_with_hint(
     with open(photo_path, "rb") as f:
         b64 = base64.b64encode(f.read()).decode()
     context = "Фото из первого запроса"
-    base = PRO_HINT_PROMPT_BASE if grade == "pro" else FREE_HINT_PROMPT_BASE
+    base = PRO_HINT_PROMPT_BASE if grade.startswith("pro") or grade.startswith("light") else FREE_HINT_PROMPT_BASE
     prompt = base.format(
         context=context,
         hint=hint,

--- a/bot/subscriptions.py
+++ b/bot/subscriptions.py
@@ -55,15 +55,33 @@ def update_limits(user: User) -> None:
     elif now.date() != user.daily_start.date():
         user.daily_start = now
         user.daily_used = 0
-    if user.grade in {"paid", "pro"}:
-        if user.period_end and now > user.period_end:
-            # subscription or trial expired
+    if user.trial and user.trial_end and now > user.trial_end:
+        if user.resume_grade:
+            user.grade = user.resume_grade
+            user.period_end = user.resume_period_end
+        else:
             user.grade = "free"
             user.request_limit = FREE_LIMIT
             user.requests_used = 0
             user.period_start = now
             user.period_end = now + timedelta(days=30)
-            user.trial = False
+            user.notified_free = True
+        user.trial = False
+        user.trial_end = None
+        user.resume_grade = None
+        user.resume_period_end = None
+        user.notified_7d = False
+        user.notified_3d = False
+        user.notified_1d = False
+        user.notified_0d = False
+        log("notification", "subscription expired for %s", user.telegram_id)
+    elif user.grade in {"light", "pro"} and not user.trial:
+        if user.period_end and now > user.period_end:
+            user.grade = "free"
+            user.request_limit = FREE_LIMIT
+            user.requests_used = 0
+            user.period_start = now
+            user.period_end = now + timedelta(days=30)
             user.notified_7d = False
             user.notified_3d = False
             user.notified_1d = False
@@ -86,21 +104,21 @@ def has_request_quota(session: SessionLocal, user: User) -> bool:
     """Check if user has remaining GPT requests without consuming one."""
     update_limits(user)
     session.commit()
-    if user.grade in {"paid", "pro"} and user.daily_used >= 100:
+    if user.grade in {"light", "pro"} and user.daily_used >= 100:
         return False
     return user.requests_used < user.request_limit
 
 
 def consume_request(session: SessionLocal, user: User) -> tuple[bool, str]:
     update_limits(user)
-    if user.grade in {"paid", "pro"} and user.daily_used >= 100:
+    if user.grade in {"light", "pro"} and user.daily_used >= 100:
         log("limit", "daily limit reached for %s", user.telegram_id)
         return False, "daily"
     if user.requests_used >= user.request_limit:
         log("limit", "monthly limit reached for %s", user.telegram_id)
         return False, "monthly"
     user.requests_used += 1
-    if user.grade in {"paid", "pro"}:
+    if user.grade in {"light", "pro"}:
         user.daily_used += 1
     session.commit()
     log("limit", "request consumed by %s", user.telegram_id)
@@ -108,13 +126,15 @@ def consume_request(session: SessionLocal, user: User) -> tuple[bool, str]:
 
 
 def days_left(user: User) -> Optional[int]:
-    if user.grade not in {"paid", "pro"} or not user.period_end:
+    if user.trial and user.trial_end:
+        return (user.trial_end.date() - datetime.utcnow().date()).days
+    if user.grade not in {"light", "pro"} or not user.period_end:
         return None
     return (user.period_end.date() - datetime.utcnow().date()).days
 
 
 def process_payment_success(
-    session: SessionLocal, user: User, months: int = 1, grade: str = "paid"
+    session: SessionLocal, user: User, months: int = 1, grade: str = "light"
 ):
     now = datetime.utcnow()
 
@@ -122,7 +142,7 @@ def process_payment_success(
         """Add count * 30 days to dt."""
         return dt + timedelta(days=30 * count)
 
-    if user.grade in {"paid", "pro"} and user.period_end and user.period_end > now:
+    if user.grade in {"light", "pro"} and user.period_end and user.period_end > now:
         user.period_end = add_period(user.period_end, months)
     else:
         user.period_end = add_period(now, months)
@@ -141,7 +161,7 @@ def process_payment_success(
 
 def add_subscription_days(session: SessionLocal, user: User, days: int) -> None:
     """Extend user's subscription by given number of days."""
-    if user.grade not in {"paid", "pro"}:
+    if user.grade not in {"light", "pro"} or user.trial:
         return
     now = datetime.utcnow()
     if user.period_end and user.period_end > now:
@@ -154,9 +174,17 @@ def add_subscription_days(session: SessionLocal, user: User, days: int) -> None:
 def start_trial(session: SessionLocal, user: User, days: int, grade: str) -> None:
     """Start a trial subscription for the user."""
     now = datetime.utcnow()
-    user.grade = grade
+    # Save current paid subscription if any
+    if user.grade in {"light", "pro"} and not user.trial:
+        user.resume_grade = user.grade
+        user.resume_period_end = (user.period_end or now) + timedelta(days=days)
+    else:
+        user.resume_grade = None
+        user.resume_period_end = None
+    trial_grade = f"{grade}_promo"
+    user.grade = trial_grade
     user.period_start = now
-    user.period_end = now + timedelta(days=days)
+    user.trial_end = now + timedelta(days=days)
     user.request_limit = PAID_LIMIT
     user.requests_used = 0
     user.daily_used = 0
@@ -184,8 +212,8 @@ def check_start_trial(session: SessionLocal, user: User) -> Optional[tuple[str, 
     if get_option_bool("trial_light_enabled", False):
         days = get_option_int("trial_light_days", 0)
         if days > 0:
-            start_trial(session, user, days, "paid")
-            return "paid", days
+            start_trial(session, user, days, "light")
+            return "light", days
     return None
 
 
@@ -205,8 +233,8 @@ async def _daily_check(bot: Bot):
     now = datetime.utcnow()
     users = session.query(User).all()
     for user in users:
-        if user.trial and user.period_end:
-            t_days = (user.period_end.date() - now.date()).days
+        if user.trial and user.trial_end:
+            t_days = (user.trial_end.date() - now.date()).days
             if t_days <= 0 and not user.notified_0d:
                 try:
                     await bot.send_message(
@@ -217,15 +245,22 @@ async def _daily_check(bot: Bot):
                     log("notification", "trial ended notice to %s", user.telegram_id)
                 except Exception:
                     pass
+                if user.resume_grade:
+                    user.grade = user.resume_grade
+                    user.period_end = user.resume_period_end
+                else:
+                    user.grade = "free"
+                    user.request_limit = FREE_LIMIT
+                    user.requests_used = 0
+                    user.period_start = now
+                    user.period_end = now + timedelta(days=30)
+                    user.notified_free = True
                 user.trial = False
-                user.grade = "free"
-                user.request_limit = FREE_LIMIT
-                user.requests_used = 0
-                user.period_start = now
-                user.period_end = now + timedelta(days=30)
+                user.trial_end = None
+                user.resume_grade = None
+                user.resume_period_end = None
                 user.notified_0d = True
-                user.notified_free = True
-        elif user.grade in {"paid", "pro"} and user.period_end and not user.trial:
+        elif user.grade in {"light", "pro"} and user.period_end and not user.trial:
             days = (user.period_end.date() - now.date()).days
             text = None
             if days <= 0 and not user.notified_0d:

--- a/bot/texts.py
+++ b/bot/texts.py
@@ -194,7 +194,7 @@ ADMIN_BLOCKED_TITLE = "Заблокированные пользователи:"
 ADMIN_BLOCKED_EMPTY = "Нет заблокированных пользователей"
 ADMIN_STATS = (
     "Всего пользователей: {total}\n"
-    "Старт: {paid}\n"
+    "Старт: {light}\n"
     "PRO: {pro}\n"
     "Free с запросами: {used}"
 )


### PR DESCRIPTION
## Summary
- rename paid tier to `light`
- store previous subscription on trial start and track promo end
- prevent granting days to trial users
- adjust prompts to treat light/promo tiers like paid
- ensure trial expiration restores prior subscription

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 || true`

------
https://chatgpt.com/codex/tasks/task_e_68703126681c832ebaa354b9a93725fa