### PR TITLE
Add light/free prompts

### DIFF
--- a/bot/prompts.py
+++ b/bot/prompts.py
@@ -16,7 +16,20 @@ PRO_PHOTO_PROMPT = (
     '{"success": true, "is_food": true, "confidence": <0–1>, "type": "<drink|meal>", "name": "<Название>", "serving": <граммы>, "calories": <ккал>, "protein": <г>, "fat": <г>, "carbs": <г>}'
 )
 
-FREE_PHOTO_PROMPT = PRO_PHOTO_PROMPT
+LIGHT_PHOTO_PROMPT = (
+    "Ты — профессиональный диетолог/нутрициолог. Анализируй фото:\n\n"
+    "Если на фото нет еды или напитка — верни\n"
+    '{"is_food": false}\n\n'
+    "Иначе (напиток в стакане или готовое блюдо) — оцени визуально вес порции в граммах и рассчитай КБЖУ (до десятых), при необходимости уточни поиск в интернете (включая FatSecret).\n\n"
+    "Всегда указывай:\n"
+    "• confidence 0.0–1.0\n"
+    '• type: "drink" или "meal"\n'
+    "• name: по-русски с заглавной буквы\n\n"
+    "Ответь строго одним JSON без пояснений:\n"
+    '{"is_food":…, "confidence":…, "type":"…", "name":"…", "serving":…, "calories":…, "protein":…, "fat":…, "carbs":…}'
+)
+
+FREE_PHOTO_PROMPT = LIGHT_PHOTO_PROMPT
 
 PRO_TEXT_PROMPT = (
     "Ты — диетолог/нутрициолог. Анализируй текст:\n\n"
@@ -30,7 +43,18 @@ PRO_TEXT_PROMPT = (
     '"calories": <ккал>, "protein": <г>, "fat": <г>, "carbs": <г>}'
 )
 
-FREE_TEXT_PROMPT = PRO_TEXT_PROMPT
+LIGHT_TEXT_PROMPT = (
+    "Ты — диетолог/нутрициолог. Анализируй текст:\n\n"
+    "Если это не еда и не напиток — верни\n"
+    '{"is_food": false}\n\n'
+    "По ингредиентам и объёмам оцени вес порции и рассчитай КБЖУ (до десятых).\n\n"
+    "Ответь строго JSON:\n"
+    '{"success": true, "is_food": true, "confidence": <0–1>, "type": "<drink|meal>", '
+    '"name": "<Название на русском с заглавной буквы>", "serving": <граммы>, '
+    '"calories": <ккал>, "protein": <г>, "fat": <г>, "carbs": <г>}'
+)
+
+FREE_TEXT_PROMPT = LIGHT_TEXT_PROMPT
 
 PRO_HINT_PROMPT_BASE = (
     "Ты — диетолог. Пользователь пишет уточнение по фото или тексту — {context}\n"
@@ -42,4 +66,13 @@ PRO_HINT_PROMPT_BASE = (
     '{{"success": true, "is_food": true, "confidence": <0–1>, "type": "<drink|meal>", "name": "<Название>", "serving": <граммы>, "calories": <ккал>, "protein": <г>, "fat": <г>, "carbs": <г>}}'
 )
 
-FREE_HINT_PROMPT_BASE = PRO_HINT_PROMPT_BASE
+LIGHT_HINT_PROMPT_BASE = (
+    "Ты — диетолог. Пользователь пишет уточнение по фото или тексту — {context}\n"
+    "Уточнение пользователя: «{hint}».\n\n"
+    "Если уточнение относится к еде — проанализируй уточнение, сравни с фото или текстом, рассчитай примерный вес и КБЖУ(до десятых).\n"
+    'Если уточнение не касается еды или продуктов — верни {"success": false}.\n\n'
+    "Ответь строго одним JSON по шаблону:\n"
+    '{{"success": true, "is_food": true, "confidence": <0–1>, "type": "<drink|meal>", "name": "<Название>", "serving": <граммы>, "calories": <ккал>, "protein": <г>, "fat": <г>, "carbs": <г>}}'
+)
+
+FREE_HINT_PROMPT_BASE = LIGHT_HINT_PROMPT_BASE

--- a/bot/services.py
+++ b/bot/services.py
@@ -12,10 +12,13 @@ from .config import OPENAI_API_KEY
 from .utils import parse_serving, to_float
 from .prompts import (
     PRO_PHOTO_PROMPT,
+    LIGHT_PHOTO_PROMPT,
     FREE_PHOTO_PROMPT,
     PRO_TEXT_PROMPT,
+    LIGHT_TEXT_PROMPT,
     FREE_TEXT_PROMPT,
     PRO_HINT_PROMPT_BASE,
+    LIGHT_HINT_PROMPT_BASE,
     FREE_HINT_PROMPT_BASE,
 )
 
@@ -210,7 +213,12 @@ async def analyze_photo(photo_path: str, grade: str = "pro") -> Dict[str, Any]:
         }
     with open(photo_path, "rb") as f:
         b64 = base64.b64encode(f.read()).decode()
-    prompt = PRO_PHOTO_PROMPT if grade.startswith("pro") or grade.startswith("light") else FREE_PHOTO_PROMPT
+    if grade.startswith("pro"):
+        prompt = PRO_PHOTO_PROMPT
+    elif grade.startswith("light"):
+        prompt = LIGHT_PHOTO_PROMPT
+    else:
+        prompt = FREE_PHOTO_PROMPT
     # The Completions API does not support images, so we always use
     # the Responses API for photo analysis regardless of user tier.
     sender = _chat
@@ -266,7 +274,12 @@ async def analyze_text(description: str, grade: str = "pro") -> Dict[str, Any]:
             "fat": 10,
             "carbs": 30,
         }
-    prompt = PRO_TEXT_PROMPT if grade.startswith("pro") or grade.startswith("light") else FREE_TEXT_PROMPT
+    if grade.startswith("pro"):
+        prompt = PRO_TEXT_PROMPT
+    elif grade.startswith("light"):
+        prompt = LIGHT_TEXT_PROMPT
+    else:
+        prompt = FREE_TEXT_PROMPT
     sender = _chat if grade.startswith("pro") or grade.startswith("light") else _completion
     content = await sender(
         [
@@ -316,7 +329,12 @@ async def analyze_text_with_hint(
             "carbs": 30,
         }
     context = f"Текст из первого запроса: {description}"
-    base = PRO_HINT_PROMPT_BASE if grade.startswith("pro") or grade.startswith("light") else FREE_HINT_PROMPT_BASE
+    if grade.startswith("pro"):
+        base = PRO_HINT_PROMPT_BASE
+    elif grade.startswith("light"):
+        base = LIGHT_HINT_PROMPT_BASE
+    else:
+        base = FREE_HINT_PROMPT_BASE
     prompt = base.format(
         context=context,
         hint=hint,
@@ -373,7 +391,12 @@ async def analyze_photo_with_hint(
     with open(photo_path, "rb") as f:
         b64 = base64.b64encode(f.read()).decode()
     context = "Фото из первого запроса"
-    base = PRO_HINT_PROMPT_BASE if grade.startswith("pro") or grade.startswith("light") else FREE_HINT_PROMPT_BASE
+    if grade.startswith("pro"):
+        base = PRO_HINT_PROMPT_BASE
+    elif grade.startswith("light"):
+        base = LIGHT_HINT_PROMPT_BASE
+    else:
+        base = FREE_HINT_PROMPT_BASE
     prompt = base.format(
         context=context,
         hint=hint,


### PR DESCRIPTION
## Summary
- create `LIGHT_*` prompt constants for photo, text, and hints
- share these prompts with the free tier
- select prompts per user grade in `services.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687141c446e0832e8c37b673ae46c7aa