### PR TITLE
Fix start mode display

### DIFF
--- a/bot/handlers/start.py
+++ b/bot/handlers/start.py
@@ -28,9 +28,10 @@ def get_welcome_text(user: User) -> str:
     else:
         days = days_left(user) or 0
         extra = REMAINING_DAYS.format(days=days)
-        grade_name = (
-            "🔸 Старт" if user.grade == "light" else "⚡ Pro-режим"
-        )
+        if user.grade.startswith("light"):
+            grade_name = "🔸 Старт"
+        else:
+            grade_name = "⚡ Pro-режим"
         grade_line = f"\nТариф: <b>{grade_name}</b>"
     return f"{BASE_TEXT}{grade_line}\n{extra}"
 


### PR DESCRIPTION
## Summary
- show correct tariff name for promo users

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6871a6fb05ec832e8bf53862bc561f30