### PR TITLE
Add calories to meal lines in report

### DIFF
--- a/bot/handlers/stats.py
+++ b/bot/handlers/stats.py
@@ -187,6 +187,7 @@ async def cb_report_day(query: types.CallbackQuery):
         line = MEAL_LINE.format(
             icon=icon,
             name=meal.name,
+            calories=int(meal.calories),
             protein=int(meal.protein),
             fat=int(meal.fat),
             carbs=int(meal.carbs),
@@ -272,6 +273,7 @@ async def report_day(message: types.Message):
         line = MEAL_LINE.format(
             icon=icon,
             name=meal.name,
+            calories=int(meal.calories),
             protein=int(meal.protein),
             fat=int(meal.fat),
             carbs=int(meal.carbs),

--- a/bot/texts.py
+++ b/bot/texts.py
@@ -270,7 +270,7 @@ REPORT_LINE_C = "• Углеводы: {carbs} г  "
 REPORT_MEALS_TITLE = "📂 Приёмы пищи:"
 MEAL_LINE = (
     "• {icon} {name}\n"
-    "(Белки: {protein} г / Жиры: {fat} г  / Углеводы: {carbs} г)"
+    "(Калории: {calories} ккал / Белки: {protein} г / Жиры: {fat} г  / Углеводы: {carbs} г)"
 )
 
 # History texts


### PR DESCRIPTION
## Summary
- include calories in MEAL_LINE text
- show calories for each meal in stats report

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687294808844832ebd8c25b53cce1dc5