### PR TITLE
Add decimal serving rounding

### DIFF
--- a/bot/handlers/callbacks.py
+++ b/bot/handlers/callbacks.py
@@ -191,9 +191,9 @@ async def _final_save(query: types.CallbackQuery, meal_id: str, fraction: float 
         await query.message.answer(BLOCKED_TEXT.format(support=SUPPORT_HANDLE))
         session.close()
         return
-    serving = parse_serving(meal.get('orig_serving', meal['serving'])) * fraction
+    serving = round(parse_serving(meal.get('orig_serving', meal['serving'])) * fraction, 1)
     macros = {
-        k: to_float(v) * fraction
+        k: round(to_float(v) * fraction, 1)
         for k, v in meal.get('orig_macros', meal['macros']).items()
     }
     name = PORTION_PREFIXES.get(fraction, "") + meal['name']
@@ -227,9 +227,9 @@ async def cb_save_full(query: types.CallbackQuery):
         await query.answer(SESSION_EXPIRED, show_alert=True)
         return
     meal['portion'] = 1.0
-    serving = int(round(meal.get('orig_serving', meal['serving']) * 1.0))
+    serving = round(meal.get('orig_serving', meal['serving']) * 1.0, 1)
     macros = {
-        k: round(v * 1.0)
+        k: round(v * 1.0, 1)
         for k, v in meal.get('orig_macros', meal['macros']).items()
     }
     meal['serving'] = serving
@@ -248,9 +248,9 @@ async def cb_save_half(query: types.CallbackQuery):
         await query.answer(SESSION_EXPIRED, show_alert=True)
         return
     meal['portion'] = 0.5
-    serving = int(round(meal.get('orig_serving', meal['serving']) * 0.5))
+    serving = round(meal.get('orig_serving', meal['serving']) * 0.5, 1)
     macros = {
-        k: round(v * 0.5)
+        k: round(v * 0.5, 1)
         for k, v in meal.get('orig_macros', meal['macros']).items()
     }
     meal['serving'] = serving
@@ -269,9 +269,9 @@ async def cb_save_quarter(query: types.CallbackQuery):
         await query.answer(SESSION_EXPIRED, show_alert=True)
         return
     meal['portion'] = 0.25
-    serving = int(round(meal.get('orig_serving', meal['serving']) * 0.25))
+    serving = round(meal.get('orig_serving', meal['serving']) * 0.25, 1)
     macros = {
-        k: round(v * 0.25)
+        k: round(v * 0.25, 1)
         for k, v in meal.get('orig_macros', meal['macros']).items()
     }
     meal['serving'] = serving
@@ -290,9 +290,9 @@ async def cb_save_threeq(query: types.CallbackQuery):
         await query.answer(SESSION_EXPIRED, show_alert=True)
         return
     meal['portion'] = 0.75
-    serving = int(round(meal.get('orig_serving', meal['serving']) * 0.75))
+    serving = round(meal.get('orig_serving', meal['serving']) * 0.75, 1)
     macros = {
-        k: round(v * 0.75)
+        k: round(v * 0.75, 1)
         for k, v in meal.get('orig_macros', meal['macros']).items()
     }
     meal['serving'] = serving

--- a/bot/handlers/history.py
+++ b/bot/handlers/history.py
@@ -62,10 +62,10 @@ def build_history_text(user_id: int, offset: int, header: bool = False):
             totals["carbs"] += m.carbs
         text_lines.extend(
             [
-                HISTORY_LINE_CAL.format(cal=int(totals['calories'])),
-                HISTORY_LINE_P.format(protein=int(totals['protein'])),
-                HISTORY_LINE_F.format(fat=int(totals['fat'])),
-                HISTORY_LINE_C.format(carbs=int(totals['carbs'])),
+                HISTORY_LINE_CAL.format(cal=round(totals['calories'], 1)),
+                HISTORY_LINE_P.format(protein=round(totals['protein'], 1)),
+                HISTORY_LINE_F.format(fat=round(totals['fat'], 1)),
+                HISTORY_LINE_C.format(carbs=round(totals['carbs'], 1)),
                 "",
             ]
         )

--- a/bot/handlers/stats.py
+++ b/bot/handlers/stats.py
@@ -115,10 +115,10 @@ async def cb_stats(query: types.CallbackQuery):
         totals['fat'] += m.fat
         totals['carbs'] += m.carbs
     text = STATS_TOTALS.format(
-        calories=int(totals['calories']),
-        protein=int(totals['protein']),
-        fat=int(totals['fat']),
-        carbs=int(totals['carbs']),
+        calories=round(totals['calories'], 1),
+        protein=round(totals['protein'], 1),
+        fat=round(totals['fat'], 1),
+        carbs=round(totals['carbs'], 1),
         chart=make_bar_chart(totals),
     )
     await query.message.edit_text(text)
@@ -172,10 +172,10 @@ async def cb_report_day(query: types.CallbackQuery):
         REPORT_HEADER,
         "",
         REPORT_TOTAL,
-        REPORT_LINE_CAL.format(cal=int(totals['calories'])),
-        REPORT_LINE_P.format(protein=int(totals['protein'])),
-        REPORT_LINE_F.format(fat=int(totals['fat'])),
-        REPORT_LINE_C.format(carbs=int(totals['carbs'])),
+        REPORT_LINE_CAL.format(cal=round(totals['calories'], 1)),
+        REPORT_LINE_P.format(protein=round(totals['protein'], 1)),
+        REPORT_LINE_F.format(fat=round(totals['fat'], 1)),
+        REPORT_LINE_C.format(carbs=round(totals['carbs'], 1)),
         "",
         REPORT_MEALS_TITLE,
     ]
@@ -187,9 +187,9 @@ async def cb_report_day(query: types.CallbackQuery):
         line = MEAL_LINE.format(
             icon=icon,
             name=meal.name,
-            protein=int(meal.protein),
-            fat=int(meal.fat),
-            carbs=int(meal.carbs),
+            protein=round(meal.protein, 1),
+            fat=round(meal.fat, 1),
+            carbs=round(meal.carbs, 1),
         )
         if getattr(meal, 'type', 'meal') == 'drink':
             drinks.append(line)
@@ -257,10 +257,10 @@ async def report_day(message: types.Message):
         REPORT_HEADER,
         "",
         REPORT_TOTAL,
-        REPORT_LINE_CAL.format(cal=int(totals['calories'])),
-        REPORT_LINE_P.format(protein=int(totals['protein'])),
-        REPORT_LINE_F.format(fat=int(totals['fat'])),
-        REPORT_LINE_C.format(carbs=int(totals['carbs'])),
+        REPORT_LINE_CAL.format(cal=round(totals['calories'], 1)),
+        REPORT_LINE_P.format(protein=round(totals['protein'], 1)),
+        REPORT_LINE_F.format(fat=round(totals['fat'], 1)),
+        REPORT_LINE_C.format(carbs=round(totals['carbs'], 1)),
         "",
         REPORT_MEALS_TITLE,
     ]
@@ -272,9 +272,9 @@ async def report_day(message: types.Message):
         line = MEAL_LINE.format(
             icon=icon,
             name=meal.name,
-            protein=int(meal.protein),
-            fat=int(meal.fat),
-            carbs=int(meal.carbs),
+            protein=round(meal.protein, 1),
+            fat=round(meal.fat, 1),
+            carbs=round(meal.carbs, 1),
         )
         if getattr(meal, 'type', 'meal') == 'drink':
             drinks.append(line)

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -24,9 +24,9 @@ def to_float(value: Any) -> float:
     return 0.0
 
 
-def parse_serving(value: Any) -> int:
-    """Parse serving size from arbitrary value in grams."""
-    return int(round(to_float(value)))
+def parse_serving(value: Any) -> float:
+    """Parse serving size from arbitrary value in grams rounded to 0.1."""
+    return round(to_float(value), 1)
 
 def make_bar_chart(totals: Dict[str, float]) -> str:
     max_val = max(totals.values()) if totals else 1


### PR DESCRIPTION
## Summary
- round serving size to one decimal in utils
- apply decimal rounding when choosing portion sizes
- include decimal values when saving meals to DB
- display calories and macros with one decimal in reports and history

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687297a4ec68832eb588287a0fa44393