### PR TITLE
Use int env for subscription interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ The bot relies on OpenAI's `gpt-4o` model for food recognition.
    `bot/config.py`. Set `ADMIN_PASSWORD` for admin access,
    `DATABASE_URL` (defaults to `sqlite:///bot.db`), and `YOOKASSA_TOKEN` for payments here. For testing, the
    `SUBSCRIPTION_CHECK_INTERVAL` (in seconds) controls how often subscription
-   statuses are checked (default `3600`).
+   statuses are checked. It is read from `.env` and converted to an integer
+   (default `3600`).
 
 3. Run the bot (package version):
    ```bash

--- a/bot/config.py
+++ b/bot/config.py
@@ -11,5 +11,7 @@ DATABASE_URL = os.getenv("DATABASE_URL", "DATABASE_URL")
 ADMIN_COMMAND = os.getenv("ADMIN_COMMAND", "admin")
 ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", "ADMIN_PASSWORD")
 YOOKASSA_TOKEN = os.getenv("YOOKASSA_TOKEN", "YOOKASSA_TOKEN")
-SUBSCRIPTION_CHECK_INTERVAL = os.getenv("SUBSCRIPTION_CHECK_INTERVAL", "SUBSCRIPTION_CHECK_INTERVAL")
+# Interval in seconds for checking subscription status. Uses 3600 seconds by
+# default if the environment variable is not set.
+SUBSCRIPTION_CHECK_INTERVAL = int(os.getenv("SUBSCRIPTION_CHECK_INTERVAL", "3600"))
 LOG_DIR = os.getenv("LOG_DIR", "logs")


### PR DESCRIPTION
## Summary
- load `SUBSCRIPTION_CHECK_INTERVAL` from `.env` as an integer
- document the env var usage in README

## Testing
- `python -m py_compile bot/config.py`


------
https://chatgpt.com/codex/tasks/task_e_6872a07b3350832eaf8d2ea5e12e8152