### PR TITLE
Fix upgrading from Start to Pro

### DIFF
--- a/bot/subscriptions.py
+++ b/bot/subscriptions.py
@@ -78,17 +78,32 @@ def update_limits(user: User) -> None:
         log("notification", "subscription expired for %s", user.telegram_id)
     elif user.grade in {"light", "pro"} and not user.trial:
         if user.period_end and now > user.period_end:
-            user.grade = "free"
-            user.request_limit = FREE_LIMIT
-            user.requests_used = 0
-            user.period_start = now
-            user.period_end = now + timedelta(days=30)
-            user.notified_7d = False
-            user.notified_3d = False
-            user.notified_1d = False
-            user.notified_0d = False
-            user.notified_free = True
-            log("notification", "subscription expired for %s", user.telegram_id)
+            if user.resume_grade:
+                user.grade = user.resume_grade
+                user.period_end = user.resume_period_end
+                user.resume_grade = None
+                user.resume_period_end = None
+                log(
+                    "notification",
+                    "subscription resumed for %s",
+                    user.telegram_id,
+                )
+            else:
+                user.grade = "free"
+                user.request_limit = FREE_LIMIT
+                user.requests_used = 0
+                user.period_start = now
+                user.period_end = now + timedelta(days=30)
+                user.notified_7d = False
+                user.notified_3d = False
+                user.notified_1d = False
+                user.notified_0d = False
+                user.notified_free = True
+                log(
+                    "notification",
+                    "subscription expired for %s",
+                    user.telegram_id,
+                )
     else:
         if user.period_end is None:
             user.period_end = user.period_start + timedelta(days=30)
@@ -149,7 +164,19 @@ def process_payment_success(
         """Add count * 30 days to dt."""
         return dt + timedelta(days=30 * count)
 
-    if user.grade in {"light", "pro"} and user.period_end and user.period_end > now:
+    current_grade = user.grade
+
+    if (
+        current_grade == "light"
+        and grade == "pro"
+        and user.period_end
+        and user.period_end > now
+        and not user.resume_grade
+    ):
+        user.resume_grade = "light"
+        user.resume_period_end = user.period_end
+
+    if current_grade == grade and user.period_end and user.period_end > now:
         user.period_end = add_period(user.period_end, months)
     else:
         user.period_end = add_period(now, months)
@@ -244,6 +271,7 @@ async def _daily_check(bot: Bot):
     now = datetime.utcnow()
     users = session.query(User).all()
     for user in users:
+        update_limits(user)
         if user.trial and user.trial_end:
             t_days = (user.trial_end.date() - now.date()).days
             if t_days <= 0 and not user.notified_0d:


### PR DESCRIPTION
## Summary
- prevent unused Start days from being added to new Pro purchase
- restore saved Start days after Pro expires
- ensure subscription watcher updates status before sending notices

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6872b258f4b4832e88129479bbe60884