### PR TITLE
Fix NameError in subscription watcher

### DIFF
--- a/bot/subscriptions.py
+++ b/bot/subscriptions.py
@@ -16,6 +16,7 @@ from .texts import (
     TRIAL_ENDED,
     TRIAL_PRO_ENDED_START,
 )
+from .settings import PLAN_PRICES, PRO_PLAN_PRICES
 
 from .database import SessionLocal, User, Payment
 


### PR DESCRIPTION
## Summary
- import `PLAN_PRICES` and `PRO_PLAN_PRICES` in `subscriptions.py`

## Testing
- `python - <<'EOF'
from bot.database import SessionLocal, engine, Base, User
from datetime import datetime, timedelta
from bot.subscriptions import _daily_check
from aiogram import Bot
import asyncio, logging

logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s - %(message)s')
Base.metadata.create_all(engine)
session = SessionLocal()
user = User(telegram_id=1, grade='light', period_end=datetime.utcnow()+timedelta(seconds=2))
session.add(user)
session.commit()
async def main():
    await _daily_check(Bot(token="123456:ABC"))
asyncio.run(main())
print("grade", SessionLocal().query(User).first().grade)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6872c8369e78832eaca65f1f69d319e5