### PR TITLE
Remove inline button from trial end start notice

### DIFF
--- a/bot/subscriptions.py
+++ b/bot/subscriptions.py
@@ -253,10 +253,11 @@ async def notify_trial_end(bot: Bot, session: SessionLocal, user: User) -> None:
         if user.resume_grade == "light" and user.grade.startswith("pro"):
             text = TRIAL_PRO_ENDED_START
         try:
+            kb = None if text == TRIAL_PRO_ENDED_START else subscribe_button(BTN_REMOVE_LIMIT)
             await bot.send_message(
                 user.telegram_id,
                 text,
-                reply_markup=subscribe_button(BTN_REMOVE_LIMIT),
+                reply_markup=kb,
             )
             log("notification", "trial ended notice to %s", user.telegram_id)
         except Exception:


### PR DESCRIPTION
## Summary
- show no reply markup after Pro trial ends and user switches back to Start

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687390c89cd0832eb6145f0a7a386e65