### PR TITLE
Fix Start subscription expiry notice after trial

### DIFF
--- a/bot/subscriptions.py
+++ b/bot/subscriptions.py
@@ -275,7 +275,10 @@ async def notify_trial_end(bot: Bot, session: SessionLocal, user: User) -> None:
         user.trial_end = None
         user.resume_grade = None
         user.resume_period_end = None
-        user.notified_0d = True
+        # Don't mark the subscription as notified about expiry yet.
+        # The user's previous plan may still be active after the trial ends,
+        # so keep this flag clear to allow future expiry reminders.
+        user.notified_0d = False
         session.commit()
 
 


### PR DESCRIPTION
## Summary
- ensure user still gets an expiry reminder for their original plan after a PRO trial ends

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687391c89a2c832e9c56374fe36e245c