### PR TITLE
Downscale images to 512x512

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ such file older than seven days. The bot keeps them only to allow clarification
 requests to reuse the original image. When a meal is entered manually, the
 initial text is stored in memory and included again whenever the user asks to
 refine the result.
+Before analysis each photo is resized to 512×512 and saved in JPEG format, so
+token usage remains predictable regardless of the original resolution.
 
 ### Manual database access
 

--- a/bot/handlers/photo.py
+++ b/bot/handlers/photo.py
@@ -122,12 +122,11 @@ async def handle_photo(message: types.Message, state: FSMContext):
     ) as tmp:
         await message.bot.download(photo.file_id, destination=tmp.name)
         photo_path = tmp.name
-    # Use the original resolution without downscaling to improve recognition
-    # consistency. Only convert to JPEG to match the API requirements.
     try:
         from PIL import Image
 
         img = Image.open(photo_path)
+        img = img.resize((512, 512), Image.LANCZOS)
         img.save(photo_path, format="JPEG", quality=95)
     except Exception:
         pass


### PR DESCRIPTION
## Summary
- resize photos to 512x512 before sending them to OpenAI
- document the new resize step in the README

## Testing
- `python -m py_compile bot/handlers/photo.py`

------
https://chatgpt.com/codex/tasks/task_e_6873a85e6adc832e8cc6cc1784ff4714