### PR TITLE
Replace Google lookup with direct Fatsecret scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,8 @@ The bot relies on OpenAI's `gpt-4o` model for food recognition.
    pip install -r requirements.txt
    ```
 2. Create a `.env` file with `BOT_TOKEN` (Telegram token) and optionally
-   `OPENAI_API_KEY` for OpenAI integration. Set `GOOGLE_API_KEY` and `GOOGLE_CX`
-   if you want to enable product lookups via Google Programmable Search. These
-   values are loaded in `bot/config.py`. When GPT responds with `"google": true`
-   the bot fetches KBJU data from fatsecret.ru using this search engine. Set `ADMIN_PASSWORD` for admin access,
+   `OPENAI_API_KEY` for OpenAI integration. When GPT responds with `"google": true`
+   the bot fetches KBJU data directly from fatsecret.ru. Set `ADMIN_PASSWORD` for admin access,
    `DATABASE_URL` (defaults to `sqlite:///bot.db`), and `YOOKASSA_TOKEN` for payments here. For testing, the
    `SUBSCRIPTION_CHECK_INTERVAL` (in seconds) controls how often subscription
    statuses are checked. It is read from `.env` and converted to an integer
@@ -44,9 +42,8 @@ Log files are written to `logs/bot.log` by default (configurable via `LOG_DIR`).
 Timestamps are displayed in Moscow time (UTC+3) even if the server uses a
 different timezone. Files rotate at Moscow midnight (21:00 UTC), and the three
 most recent days are kept. Token usage for each OpenAI request is logged under
-the `tokens` category, showing input, output and total token counts. Queries to
-Google Programmable Search and parsed macros are logged under the `google`
-category.
+the `tokens` category, showing input, output and total token counts. Lookups on
+fatsecret.ru and parsed macros are logged under the `google` category.
 
 
 ### Custom prompts

--- a/bot/config.py
+++ b/bot/config.py
@@ -15,5 +15,3 @@ YOOKASSA_TOKEN = os.getenv("YOOKASSA_TOKEN", "YOOKASSA_TOKEN")
 # Defaults to 10 minutes if the environment variable is missing.
 SUBSCRIPTION_CHECK_INTERVAL = int(os.getenv("SUBSCRIPTION_CHECK_INTERVAL", "1800"))
 LOG_DIR = os.getenv("LOG_DIR", "logs")
-GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY", "")
-GOOGLE_CX = os.getenv("GOOGLE_CX", "")

--- a/bot/handlers/manual.py
+++ b/bot/handlers/manual.py
@@ -4,7 +4,7 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 from aiogram.filters import StateFilter
 from datetime import timedelta
 
-from ..services import analyze_text, _google_lookup
+from ..services import analyze_text, fatsecret_lookup
 from ..utils import format_meal_message, parse_serving, to_float
 from ..keyboards import (
     meal_actions_kb,
@@ -136,7 +136,7 @@ async def process_manual(message: types.Message, state: FSMContext):
             "carbs": to_float(res.get("carbs", 0)),
         }
         if grade.startswith("pro") and res.get("google"):
-            gmacros = await _google_lookup(name)
+            gmacros = await fatsecret_lookup(name)
             if gmacros:
                 macros.update(gmacros)
         meal_id = f"{message.from_user.id}_{message.message_id}_{idx}"

--- a/bot/handlers/photo.py
+++ b/bot/handlers/photo.py
@@ -4,7 +4,7 @@ import tempfile
 from aiogram.fsm.context import FSMContext
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 
-from ..services import analyze_photo, _google_lookup
+from ..services import analyze_photo, fatsecret_lookup
 from ..utils import format_meal_message, parse_serving, to_float
 from ..keyboards import meal_actions_kb, back_menu_kb, subscribe_button
 from ..subscriptions import consume_request, ensure_user, has_request_quota, notify_trial_end
@@ -154,7 +154,7 @@ async def handle_photo(message: types.Message, state: FSMContext):
             "carbs": to_float(res.get("carbs", 0)),
         }
         if grade.startswith("pro") and res.get("google"):
-            gmacros = await _google_lookup(name)
+            gmacros = await fatsecret_lookup(name)
             if gmacros:
                 macros.update(gmacros)
 

--- a/bot/services.py
+++ b/bot/services.py
@@ -10,7 +10,7 @@ from .logger import log
 import openai
 from openai import RateLimitError, BadRequestError
 
-from .config import OPENAI_API_KEY, GOOGLE_API_KEY, GOOGLE_CX
+from .config import OPENAI_API_KEY
 from .utils import parse_serving, to_float
 from .prompts import (
     PRO_PHOTO_PROMPT,
@@ -31,49 +31,34 @@ MODEL_NAME = "gpt-4.1-mini"
 COMPLETION_MODEL = "gpt-4.1-mini"
 
 
-async def _google_lookup(name: str) -> Optional[Dict[str, float]]:
-    """Search fatsecret.ru via Google CSE and parse macros."""
-    if not GOOGLE_API_KEY or not GOOGLE_CX:
-        return None
+
+
+async def fatsecret_lookup(name: str) -> Optional[Dict[str, float]]:
+    """Fetch macros for the first search result on fatsecret.ru."""
     log("google", "query %s", name)
     loop = asyncio.get_running_loop()
     try:
-        resp = await loop.run_in_executor(
-            None,
-            lambda: requests.get(
-                "https://www.googleapis.com/customsearch/v1",
-                params={"key": GOOGLE_API_KEY, "cx": GOOGLE_CX, "q": name},
-                timeout=10,
-            ),
-        )
-        data = resp.json()
-        log("google", "search %s", data)
-        items = data.get("items")
-        if not items:
-            return None
-        link = items[0].get("link")
-        log("google", "link %s", link)
-        if not link:
-            return None
         page = await loop.run_in_executor(
             None,
             lambda: requests.get(
-                link,
-                timeout=10,
+                "https://www.fatsecret.ru/\u043a\u0430\u043b\u043e\u0440\u0438\u0438-\u043f\u0438\u0442\u0430\u043d\u0438\u0435/search",
+                params={"q": name},
                 headers={"User-Agent": "Mozilla/5.0"},
                 verify=False,
+                timeout=10,
             ),
         )
         soup = BeautifulSoup(page.text, "html.parser")
-        text = soup.get_text(" ", strip=True)
+        block = soup.select_one("table.searchResult")
+        text = block.get_text(" ", strip=True) if block else soup.get_text(" ", strip=True)
         m = re.search(
-            r"Калории[^\d]*(\d+(?:[\.,]\d+)?)\s*ккал.*?Белк[аи][^\d]*(\d+(?:[\.,]\d+)?)\s*г.*?Жир[^\d]*(\d+(?:[\.,]\d+)?)\s*г.*?Углевод[^\d]*(\d+(?:[\.,]\d+)?)\s*г",
+            r"Калории[^\d]*(\d+(?:[\.,]\d+)?)\s*ккал[^\d]*Жир[^\d]*(\d+(?:[\.,]\d+)?)\s*г[^\d]*Углев[^\d]*(\d+(?:[\.,]\d+)?)\s*г[^\d]*Белк[^\d]*(\d+(?:[\.,]\d+)?)\s*г",
             text,
             re.I | re.S,
         )
         if not m:
             return None
-        calories, protein, fat, carbs = m.groups()
+        calories, fat, carbs, protein = m.groups()
         macros = {
             "calories": to_float(calories),
             "protein": to_float(protein),


### PR DESCRIPTION
## Summary
- parse Fatsecret search results directly instead of using Google CSE
- update manual and photo handlers to use the new lookup
- drop Google API variables from config and docs

## Testing
- `python3 -m pip install -r requirements.txt`
- `python -m compileall -q bot`


------
https://chatgpt.com/codex/tasks/task_e_688643e718a8832e8b4c057adb1e90d4