### PR TITLE
Refactor users table

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ sqlite3 bot.db
 
 Within the shell you can list tables with `.tables`, show table schemas with
 `.schema users`, `.schema meals` or `.schema payments` and execute regular SQL
+queries. Additional user data lives in `subscriptions`, `notification_status`
+and `reminders` tables.
 statements. For example, granting a user light status:
 
 ```sql

--- a/bot/reminders.py
+++ b/bot/reminders.py
@@ -28,7 +28,14 @@ def reminder_watcher(check_interval: int = 60):
         while True:
             now = datetime.utcnow()
             session = SessionLocal()
-            users = session.query(User).filter(User.timezone != None).all()
+            from .database import ReminderSettings
+
+            users = (
+                session.query(User)
+                .join(ReminderSettings)
+                .filter(ReminderSettings.timezone != None)
+                .all()
+            )
             for user in users:
                 offset = timedelta(minutes=user.timezone or 0)
                 local_now = now + offset

--- a/bot/subscriptions.py
+++ b/bot/subscriptions.py
@@ -19,7 +19,14 @@ from .texts import (
 )
 from .settings import PLAN_PRICES, PRO_PLAN_PRICES
 
-from .database import SessionLocal, User, Payment
+from .database import (
+    SessionLocal,
+    User,
+    Payment,
+    Subscription,
+    NotificationStatus,
+    ReminderSettings,
+)
 
 from .logger import log
 
@@ -47,8 +54,8 @@ def ensure_user(session: SessionLocal, telegram_id: int) -> User:
     user = session.query(User).filter_by(telegram_id=telegram_id).first()
     if not user:
         now = datetime.utcnow()
-        user = User(
-            telegram_id=telegram_id,
+        user = User(telegram_id=telegram_id)
+        user.subscription = Subscription(
             grade="free",
             request_limit=FREE_LIMIT,
             requests_used=0,
@@ -57,11 +64,14 @@ def ensure_user(session: SessionLocal, telegram_id: int) -> User:
             monthly_start=now,
             period_start=now,
             period_end=now + timedelta(days=30),
-            notified_1d=False,
-            notified_free=True,
             daily_used=0,
             daily_start=now,
         )
+        user.notification = NotificationStatus(
+            notified_1d=False,
+            notified_free=True,
+        )
+        user.reminders = ReminderSettings()
         session.add(user)
         session.commit()
     return user


### PR DESCRIPTION
## Summary
- split user data into new tables (`subscriptions`, `notification_status`, `reminders`)
- create relationships and proxy properties on `User`
- update admin stats and bulk operations
- adjust reminder watcher and default README info

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68891a9e38ac832eacad490f40a580b4