### PR TITLE
Fix invalid markup for save confirmation

### DIFF
--- a/bot/handlers/callbacks.py
+++ b/bot/handlers/callbacks.py
@@ -283,7 +283,7 @@ async def _final_save(query: types.CallbackQuery, meal_id: str, fraction: float 
     session.commit()
     log("meal_save", "meal saved for %s: %s %s g", query.from_user.id, name, serving)
     session.close()
-    await query.message.edit_text(SAVE_DONE, reply_markup=main_menu_kb())
+    await query.message.edit_text(SAVE_DONE)
     await query.answer()
 
 


### PR DESCRIPTION
## Summary
- fix incorrect reply markup when confirming a meal save
- remove stub menu message after saving meals

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_688a7dac42f0832e9cb2db6a16140a42