### PR TITLE
Fix invalid markup for save confirmation

### DIFF
--- a/bot/handlers/callbacks.py
+++ b/bot/handlers/callbacks.py
@@ -283,7 +283,7 @@ async def _final_save(query: types.CallbackQuery, meal_id: str, fraction: float 
     session.commit()
     log("meal_save", "meal saved for %s: %s %s g", query.from_user.id, name, serving)
     session.close()
-    await query.message.edit_text(SAVE_DONE, reply_markup=main_menu_kb())
+    await query.message.edit_text(SAVE_DONE)
     await query.answer()
 
 

--- a/bot/handlers/start.py
+++ b/bot/handlers/start.py
@@ -57,7 +57,11 @@ async def cmd_start(message: types.Message):
     # "Меню" and "ЧаВО" buttons remain persistent for the user.
     from ..texts import MENU_STUB
 
-    await message.answer(MENU_STUB, reply_markup=main_menu_kb())
+    stub = await message.answer(MENU_STUB, reply_markup=main_menu_kb())
+    try:
+        await stub.delete()
+    except Exception:
+        pass
     if trial:
         grade, days = trial
         grade_name = "⚡ Pro-режим" if grade == "pro" else "🔸 Старт"
@@ -87,7 +91,11 @@ async def back_to_menu(message: types.Message):
     session.close()
     from ..texts import MENU_STUB
 
-    await message.answer(MENU_STUB, reply_markup=main_menu_kb())
+    stub = await message.answer(MENU_STUB, reply_markup=main_menu_kb())
+    try:
+        await stub.delete()
+    except Exception:
+        pass
     await message.answer(text, reply_markup=menu_inline_kb(), parse_mode="HTML")
 
 


### PR DESCRIPTION
## Summary
- fix incorrect reply markup when confirming a meal save
- remove stub menu message after saving meals
- hide the temporary keyboard message when entering the main menu
- delete user time messages and edit prompts instead of sending new ones

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_688a7dac42f0832e9cb2db6a16140a42