### PR TITLE
Keep menu visible

### DIFF
--- a/bot/handlers/callbacks.py
+++ b/bot/handlers/callbacks.py
@@ -36,6 +36,7 @@ from ..texts import (
     PORTION_PREFIXES,
     LOOKUP_PROMPT,
     LOOKUP_WEIGHT,
+    MENU_STUB,
 )
 from ..logger import log
 
@@ -283,7 +284,12 @@ async def _final_save(query: types.CallbackQuery, meal_id: str, fraction: float 
     session.commit()
     log("meal_save", "meal saved for %s: %s %s g", query.from_user.id, name, serving)
     session.close()
-    await query.message.edit_text(SAVE_DONE, reply_markup=main_menu_kb())
+    await query.message.edit_text(SAVE_DONE)
+    stub = await query.message.answer(MENU_STUB, reply_markup=main_menu_kb())
+    try:
+        await stub.edit_text("\u2063")
+    except Exception:
+        pass
     await query.answer()
 
 

--- a/bot/handlers/start.py
+++ b/bot/handlers/start.py
@@ -57,7 +57,7 @@ async def cmd_start(message: types.Message):
     # "Меню" and "ЧаВО" buttons remain persistent for the user.
     from ..texts import MENU_STUB
 
-    await message.answer(MENU_STUB, reply_markup=main_menu_kb())
+    stub = await message.answer(MENU_STUB, reply_markup=main_menu_kb())
     if trial:
         grade, days = trial
         grade_name = "⚡ Pro-режим" if grade == "pro" else "🔸 Старт"
@@ -68,6 +68,10 @@ async def cmd_start(message: types.Message):
             parse_mode="HTML",
         )
     await message.answer(text, reply_markup=menu_inline_kb(), parse_mode="HTML")
+    try:
+        await stub.edit_text("\u2063")
+    except Exception:
+        pass
 
 
 async def back_to_menu(message: types.Message):
@@ -87,8 +91,16 @@ async def back_to_menu(message: types.Message):
     session.close()
     from ..texts import MENU_STUB
 
-    await message.answer(MENU_STUB, reply_markup=main_menu_kb())
+    try:
+        await message.delete()
+    except Exception:
+        pass
+    stub = await message.answer(MENU_STUB, reply_markup=main_menu_kb())
     await message.answer(text, reply_markup=menu_inline_kb(), parse_mode="HTML")
+    try:
+        await stub.edit_text("\u2063")
+    except Exception:
+        pass
 
 
 async def cb_menu(query: types.CallbackQuery):

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -163,6 +163,7 @@ def main_menu_kb() -> ReplyKeyboardMarkup:
             [KeyboardButton(text=BTN_FAQ)],
         ],
         resize_keyboard=True,
+        is_persistent=True,
     )
 
 


### PR DESCRIPTION
## Summary
- persist the reply keyboard with the menu buttons
- hide the stub messages after sending

## Testing
- `python -m compileall -q bot`


------
https://chatgpt.com/codex/tasks/task_e_688a7dac42f0832e9cb2db6a16140a42