### PR TITLE
Fix final save reply keyboard

### DIFF
--- a/bot/handlers/callbacks.py
+++ b/bot/handlers/callbacks.py
@@ -285,7 +285,7 @@ async def _final_save(query: types.CallbackQuery, meal_id: str, fraction: float 
     session.commit()
     log("meal_save", "meal saved for %s: %s %s g", query.from_user.id, name, serving)
     session.close()
-    await query.message.edit_text(SAVE_DONE, reply_markup=main_menu_kb())
+    await query.message.edit_text(SAVE_DONE)
     stub = await query.message.answer(MENU_STUB, reply_markup=main_menu_kb())
     try:
         await stub.edit_text("\u2063")


### PR DESCRIPTION
## Summary
- ensure editing the save message doesn't attach a ReplyKeyboardMarkup

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688bb7baa760832e8d85e85a9f3af558