### PR TITLE
Add alert bot integration with monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ The bot relies on OpenAI's `gpt-4o` model for food recognition.
    ```
 2. Create a `.env` file with `BOT_TOKEN` (Telegram token) and optionally
    `OPENAI_API_KEY` for OpenAI integration. When GPT responds with `"google": true`
-  the bot fetches KBJU data directly from fatsecret.ru. Search results show macros per 100 g.
+   the bot fetches KBJU data directly from fatsecret.ru. Search results show macros per 100 g.
    Set `ADMIN_PASSWORD` for admin access,
    `DATABASE_URL` (defaults to `sqlite:///bot.db`), and `YOOKASSA_TOKEN` for payments here. For testing, the
    `SUBSCRIPTION_CHECK_INTERVAL` (in seconds) controls how often subscription
    statuses are checked. It is read from `.env` and converted to an integer
-   (default `3600`).
+   (default `3600`). If you want alerts in a separate bot/chat, also provide
+   `ALERT_BOT_TOKEN` and `ALERT_CHAT_ID`.
 
 3. Run the bot (package version):
    ```bash

--- a/bot/alerts.py
+++ b/bot/alerts.py
@@ -1,0 +1,129 @@
+import asyncio
+from datetime import datetime, timedelta, time
+from aiogram import Bot
+
+from .config import ALERT_BOT_TOKEN, ALERT_CHAT_ID as ALERT_CHAT_ID_CONFIG
+from .database import get_option, get_option_int, set_option
+
+
+alert_bot = Bot(token=ALERT_BOT_TOKEN) if ALERT_BOT_TOKEN else None
+ALERT_CHAT_ID = ALERT_CHAT_ID_CONFIG or None
+
+
+async def send_alert(text: str) -> None:
+    """Send raw text to the alert chat if configured."""
+    if not alert_bot or not ALERT_CHAT_ID:
+        return
+    try:
+        await alert_bot.send_message(ALERT_CHAT_ID, text)
+    except Exception:
+        pass
+
+
+class TokenMonitor:
+    """Track daily token usage and emit alerts."""
+
+    def __init__(self) -> None:
+        today = datetime.utcnow().date()
+        stored = get_option("tokens_date", today.isoformat())
+        try:
+            self.date = datetime.fromisoformat(stored).date()
+        except Exception:
+            self.date = today
+        self.input = get_option_int("tokens_input", 0)
+        self.output = get_option_int("tokens_output", 0)
+        self.next_alert = get_option_int("tokens_next_alert", 1_000_000)
+
+    def _save(self) -> None:
+        set_option("tokens_date", self.date.isoformat())
+        set_option("tokens_input", str(self.input))
+        set_option("tokens_output", str(self.output))
+        set_option("tokens_next_alert", str(self.next_alert))
+
+    def _check_date(self) -> None:
+        today = datetime.utcnow().date()
+        if today != self.date:
+            self.date = today
+            self.input = 0
+            self.output = 0
+            self.next_alert = 1_000_000
+            self._save()
+
+    async def add(self, tokens_in: int, tokens_out: int) -> None:
+        if tokens_in == 0 and tokens_out == 0:
+            return
+        if not alert_bot or not ALERT_CHAT_ID:
+            return
+        self._check_date()
+        self.input += tokens_in
+        self.output += tokens_out
+        self._save()
+        total = self.input + self.output
+        if total >= self.next_alert:
+            await send_alert(
+                f"1млн токенов\nInput: {self.input}\nOutput: {self.output}\n"
+            )
+            self.next_alert += 1_000_000
+            self._save()
+
+    async def report_and_reset(self) -> None:
+        if alert_bot and ALERT_CHAT_ID:
+            total = self.input + self.output
+            await send_alert(
+                f"Отчет по токенам:\nInput: {self.input}\nOutput: {self.output}\nОбщее: {total}"
+            )
+        self.date = datetime.utcnow().date()
+        self.input = 0
+        self.output = 0
+        self.next_alert = 1_000_000
+        self._save()
+
+
+token_monitor = TokenMonitor()
+
+
+async def new_user(telegram_id: int) -> None:
+    await send_alert(f"Новый пользователь {telegram_id}")
+
+
+async def subscription_paid(
+    telegram_id: int, count: int, tier: str, months: int
+) -> None:
+    await send_alert(
+        f"Подписка оплачена {count}раз  {telegram_id} на {tier} {months} мес"
+    )
+
+
+async def user_left(telegram_id: int) -> None:
+    await send_alert(f"Пользователь {telegram_id} вышел из бота")
+
+
+async def gpt_error(message: str) -> None:
+    await send_alert(f"Ошибка {message}")
+
+
+async def anomalous_activity(telegram_id: int, n: int) -> None:
+    await send_alert(f"Аномальная активность пользователя {telegram_id}: {n} запросов")
+
+
+async def user_blocked_daily(telegram_id: int) -> None:
+    await send_alert(
+        f"Пользователь {telegram_id} заблокирован за 100 запросов в день"
+    )
+
+
+async def monthly_limit(telegram_id: int) -> None:
+    await send_alert(
+        f"Пользователь {telegram_id} пробил 800 запросов за текущий месяц"
+    )
+
+
+async def token_watcher() -> None:
+    """Send daily token report at midnight UTC and reset counters."""
+    while True:
+        now = datetime.utcnow()
+        tomorrow = now.date() + timedelta(days=1)
+        midnight = datetime.combine(tomorrow, time())
+        await asyncio.sleep((midnight - now).total_seconds())
+        await token_monitor.report_and_reset()
+

--- a/bot/config.py
+++ b/bot/config.py
@@ -11,6 +11,9 @@ DATABASE_URL = os.getenv("DATABASE_URL", "DATABASE_URL")
 ADMIN_COMMAND = os.getenv("ADMIN_COMMAND", "admin")
 ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", "ADMIN_PASSWORD")
 YOOKASSA_TOKEN = os.getenv("YOOKASSA_TOKEN", "YOOKASSA_TOKEN")
+# Optional second bot for alerts
+ALERT_BOT_TOKEN = os.getenv("ALERT_BOT_TOKEN")
+ALERT_CHAT_ID = int(os.getenv("ALERT_CHAT_ID", "0"))
 # Interval in seconds for checking subscription status.
 # Defaults to 10 minutes if the environment variable is missing.
 SUBSCRIPTION_CHECK_INTERVAL = int(os.getenv("SUBSCRIPTION_CHECK_INTERVAL", "1800"))

--- a/bot/main.py
+++ b/bot/main.py
@@ -11,6 +11,7 @@ from .handlers import start, photo, history, stats, callbacks, faq, admin, subsc
 from .subscriptions import subscription_watcher
 from .cleanup import cleanup_watcher
 from .reminders import reminder_watcher
+from .alerts import token_watcher
 from .error_handler import handle_error
 
 bot = Bot(token=API_TOKEN)
@@ -34,10 +35,12 @@ async def main() -> None:
     watcher = subscription_watcher(bot, check_interval=SUBSCRIPTION_CHECK_INTERVAL)()
     cleanup = cleanup_watcher()()
     reminder = reminder_watcher()(bot)
+    tokens = token_watcher()
     tasks = [
         asyncio.create_task(watcher),
         asyncio.create_task(cleanup),
         asyncio.create_task(reminder),
+        asyncio.create_task(tokens),
     ]
     await dp.start_polling(bot)
     for t in tasks:


### PR DESCRIPTION
## Summary
- integrate secondary alert bot with token counter and daily reports
- track user activity to send alerts and auto-block after 100 daily requests
- report payments, new/left users and GPT errors to alert bot

## Testing
- `pytest`
- `python -m py_compile bot/config.py bot/handlers/start.py bot/handlers/subscription.py bot/main.py bot/services.py bot/subscriptions.py bot/alerts.py`


------
https://chatgpt.com/codex/tasks/task_e_688e8fe14248832e9309eb9ac0832f86