### PR TITLE
feat: support multiple alert chats

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+BOT_TOKEN=your_bot_token_here
+OPENAI_API_KEY=your_openai_api_key
+DATABASE_URL=sqlite:///bot.db
+ADMIN_COMMAND=admin
+ADMIN_PASSWORD=your_admin_password
+YOOKASSA_TOKEN=your_yookassa_token
+ALERT_BOT_TOKEN=your_alert_bot_token
+ALERT_CHAT_IDS=123456789,987654321
+SUBSCRIPTION_CHECK_INTERVAL=1800
+LOG_DIR=logs

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ The bot relies on OpenAI's `gpt-4o` model for food recognition.
    `SUBSCRIPTION_CHECK_INTERVAL` (in seconds) controls how often subscription
    statuses are checked. It is read from `.env` and converted to an integer
    (default `3600`). If you want alerts in a separate bot/chat, also provide
-   `ALERT_BOT_TOKEN` and `ALERT_CHAT_ID`. To discover the chat ID, run
-   `python -m bot.alerts` and send any message to your alert bot—the ID will be
-   logged and echoed back.
+   `ALERT_BOT_TOKEN` and `ALERT_CHAT_IDS` (comma-separated chat IDs). To discover
+   chat IDs, run `python -m bot.alerts` and send any message to your alert bot—
+   the IDs will be logged and echoed back.
 
 3. Run the bot (package version):
    ```bash

--- a/bot/config.py
+++ b/bot/config.py
@@ -13,7 +13,8 @@ ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", "ADMIN_PASSWORD")
 YOOKASSA_TOKEN = os.getenv("YOOKASSA_TOKEN", "YOOKASSA_TOKEN")
 # Optional second bot for alerts
 ALERT_BOT_TOKEN = os.getenv("ALERT_BOT_TOKEN")
-ALERT_CHAT_ID = int(os.getenv("ALERT_CHAT_ID", "0"))
+# Comma-separated list of chat IDs for alerts
+ALERT_CHAT_IDS = [int(x) for x in os.getenv("ALERT_CHAT_IDS", "").split(",") if x]
 # Interval in seconds for checking subscription status.
 # Defaults to 10 minutes if the environment variable is missing.
 SUBSCRIPTION_CHECK_INTERVAL = int(os.getenv("SUBSCRIPTION_CHECK_INTERVAL", "1800"))


### PR DESCRIPTION
## Summary
- Allow configuring multiple alert chat IDs via `ALERT_CHAT_IDS`
- Broadcast alerts to every configured chat
- Document new `ALERT_CHAT_IDS` environment variable and provide `.env.example`

## Testing
- `python -m py_compile bot/config.py bot/alerts.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e9a9ac794832eba2ca9776be2c458