### PR TITLE
Allow free users to consume request quota

### DIFF
--- a/bot/handlers/callbacks.py
+++ b/bot/handlers/callbacks.py
@@ -183,16 +183,6 @@ async def process_edit(message: types.Message, state: FSMContext):
         session.close()
         await state.clear()
         return
-    if user.grade == "free":
-        from ..texts import SUB_REQUIRED, BTN_SUBSCRIPTION
-        await message.answer(
-            SUB_REQUIRED,
-            reply_markup=subscribe_button(BTN_SUBSCRIPTION),
-            parse_mode="HTML",
-        )
-        session.close()
-        await state.clear()
-        return
     grade = user.grade
     session.close()
     MAX_LEN = 200

--- a/bot/handlers/photo.py
+++ b/bot/handlers/photo.py
@@ -48,15 +48,6 @@ async def request_photo(message: types.Message):
         await message.answer(BLOCKED_TEXT.format(support=SUPPORT_HANDLE))
         session.close()
         return
-    if user.grade == "free":
-        from ..texts import SUB_REQUIRED, BTN_SUBSCRIPTION
-        await message.answer(
-            SUB_REQUIRED,
-            reply_markup=subscribe_button(BTN_SUBSCRIPTION),
-            parse_mode="HTML",
-        )
-        session.close()
-        return
     if not has_request_quota(session, user):
         reset = (
             user.period_end.date()
@@ -95,15 +86,6 @@ async def handle_photo(message: types.Message, state: FSMContext):
         from ..texts import BLOCKED_TEXT
 
         await message.answer(BLOCKED_TEXT.format(support=SUPPORT_HANDLE))
-        session.close()
-        return
-    if user.grade == "free":
-        from ..texts import SUB_REQUIRED, BTN_SUBSCRIPTION
-        await message.answer(
-            SUB_REQUIRED,
-            reply_markup=subscribe_button(BTN_SUBSCRIPTION),
-            parse_mode="HTML",
-        )
         session.close()
         return
     ok, reason = consume_request(session, user)


### PR DESCRIPTION
## Summary
- Let free-tier users submit manual entries and photos while still respecting request limits
- Use quota checks instead of subscription gates for manual and photo flows
- Permit refinement callbacks for free users

## Testing
- `python -m py_compile bot/handlers/manual.py bot/handlers/photo.py bot/handlers/callbacks.py`
- `python - <<'PY'
from bot.subscriptions import ensure_user, consume_request, has_request_quota
from bot.database import SessionLocal, User, Subscription

session = SessionLocal()
user = ensure_user(session, 123456789)
print('initial requests_used', user.requests_used)
print('has_quota', has_request_quota(session, user))
ok, reason = consume_request(session, user)
print('consume_result', ok, reason)
session.refresh(user.subscription)
print('after consume requests_used', user.requests_used)
used = (
    session.query(User)
    .join(Subscription)
    .filter(Subscription.grade == 'free', Subscription.requests_used > 0)
    .count()
)
print('free with requests', used)
session.close()
PY`

------
https://chatgpt.com/codex/tasks/task_e_688eac0f6b0c832e884f6609e40660ab