### PR TITLE
Allow free users to consume request quota

### DIFF
--- a/bot/handlers/callbacks.py
+++ b/bot/handlers/callbacks.py
@@ -183,16 +183,6 @@ async def process_edit(message: types.Message, state: FSMContext):
         session.close()
         await state.clear()
         return
-    if user.grade == "free":
-        from ..texts import SUB_REQUIRED, BTN_SUBSCRIPTION
-        await message.answer(
-            SUB_REQUIRED,
-            reply_markup=subscribe_button(BTN_SUBSCRIPTION),
-            parse_mode="HTML",
-        )
-        session.close()
-        await state.clear()
-        return
     grade = user.grade
     session.close()
     MAX_LEN = 200

--- a/bot/handlers/photo.py
+++ b/bot/handlers/photo.py
@@ -48,15 +48,6 @@ async def request_photo(message: types.Message):
         await message.answer(BLOCKED_TEXT.format(support=SUPPORT_HANDLE))
         session.close()
         return
-    if user.grade == "free":
-        from ..texts import SUB_REQUIRED, BTN_SUBSCRIPTION
-        await message.answer(
-            SUB_REQUIRED,
-            reply_markup=subscribe_button(BTN_SUBSCRIPTION),
-            parse_mode="HTML",
-        )
-        session.close()
-        return
     if not has_request_quota(session, user):
         reset = (
             user.period_end.date()
@@ -95,15 +86,6 @@ async def handle_photo(message: types.Message, state: FSMContext):
         from ..texts import BLOCKED_TEXT
 
         await message.answer(BLOCKED_TEXT.format(support=SUPPORT_HANDLE))
-        session.close()
-        return
-    if user.grade == "free":
-        from ..texts import SUB_REQUIRED, BTN_SUBSCRIPTION
-        await message.answer(
-            SUB_REQUIRED,
-            reply_markup=subscribe_button(BTN_SUBSCRIPTION),
-            parse_mode="HTML",
-        )
         session.close()
         return
     ok, reason = consume_request(session, user)

--- a/bot/main.py
+++ b/bot/main.py
@@ -11,7 +11,7 @@ from .handlers import start, photo, history, stats, callbacks, faq, admin, subsc
 from .subscriptions import subscription_watcher
 from .cleanup import cleanup_watcher
 from .reminders import reminder_watcher
-from .alerts import token_watcher, user_stats_watcher
+from .alerts import token_watcher, user_stats_watcher, setup_error_alerts
 from .error_handler import handle_error
 
 bot = Bot(token=API_TOKEN)
@@ -76,5 +76,6 @@ if __name__ == '__main__':
     stream_handler = logging.StreamHandler()
     stream_handler.setFormatter(formatter)
     logging.basicConfig(level=logging.INFO, handlers=[file_handler, stream_handler])
+    setup_error_alerts()
 
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- Let free-tier users submit manual entries and photos while still respecting request limits
- Use quota checks instead of subscription gates for manual and photo flows
- Permit refinement callbacks for free users
- Forward any logged errors to alert chats with full stack traces

## Testing
- `python -m py_compile bot/alerts.py bot/main.py`
- `python - <<'PY'
import os
os.environ['DATABASE_URL']='sqlite://'
import logging
import asyncio
from bot import alerts

class Dummy:
    async def send_message(self, chat_id, message):
        print('sent', chat_id, message.splitlines()[0])

alerts.alert_bot = Dummy()
alerts.ALERT_CHAT_IDS = [123]
alerts.setup_error_alerts()

try:
    1/0
except ZeroDivisionError:
    logging.exception('boom')

asyncio.run(asyncio.sleep(0.1))
print('done')
PY`


------
https://chatgpt.com/codex/tasks/task_e_688eac0f6b0c832e884f6609e40660ab