### PR TITLE
Track users leaving and returning

### DIFF
--- a/bot/alerts.py
+++ b/bot/alerts.py
@@ -139,6 +139,10 @@ async def user_left(telegram_id: int) -> None:
     await send_alert(f"Пользователь {telegram_id} вышел из бота")
 
 
+async def user_unblocked(telegram_id: int) -> None:
+    await send_alert(f"Пользователь {telegram_id} разблокировал бота")
+
+
 async def gpt_error(message: str) -> None:
     await send_alert(f"Ошибка {message}")
 

--- a/bot/database.py
+++ b/bot/database.py
@@ -38,7 +38,17 @@ def _ensure_columns():
     bool_default = "0" if engine.dialect.name == "sqlite" else "FALSE"
     with engine.begin() as conn:
         if "blocked" not in existing:
-            conn.execute(text(f"ALTER TABLE users ADD COLUMN blocked BOOLEAN DEFAULT {bool_default}"))
+            conn.execute(
+                text(
+                    f"ALTER TABLE users ADD COLUMN blocked BOOLEAN DEFAULT {bool_default}"
+                )
+            )
+        if "left_bot" not in existing:
+            conn.execute(
+                text(
+                    f"ALTER TABLE users ADD COLUMN left_bot BOOLEAN DEFAULT {bool_default}"
+                )
+            )
 
     existing = _column_names("meals")
     with engine.begin() as conn:
@@ -52,6 +62,7 @@ class User(Base):
     telegram_id = Column(BigInteger, unique=True, index=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     blocked = Column(Boolean, default=False)
+    left_bot = Column(Boolean, default=False)
 
     subscription = relationship(
         'Subscription', back_populates='user', uselist=False, cascade='all, delete-orphan'

--- a/bot/handlers/admin.py
+++ b/bot/handlers/admin.py
@@ -299,6 +299,7 @@ async def admin_stats(query: types.CallbackQuery):
         .filter(Subscription.grade == "free", Subscription.requests_used > 0)
         .count()
     )
+    left = session.query(User).filter_by(left_bot=True).count()
     from ..database import RequestLog
     start_today = now.replace(hour=0, minute=0, second=0, microsecond=0)
     q_today = session.query(RequestLog).filter(RequestLog.timestamp >= start_today).count()
@@ -310,6 +311,7 @@ async def admin_stats(query: types.CallbackQuery):
         trial_pro=trial_pro,
         trial_light=trial_light,
         used=used,
+        left=left,
         req_today=q_today,
     )
     try:

--- a/bot/handlers/start.py
+++ b/bot/handlers/start.py
@@ -82,9 +82,30 @@ async def cmd_start(message: types.Message):
 
 async def on_user_left(event: types.ChatMemberUpdated):
     if event.chat.type == "private" and event.new_chat_member.status in {"kicked", "left"}:
+        session = SessionLocal()
+        user = ensure_user(session, event.from_user.id)
+        user.left_bot = True
+        session.commit()
+        session.close()
         from ..alerts import user_left as alert_user_left
 
         await alert_user_left(event.from_user.id)
+
+
+async def on_user_unblocked(event: types.ChatMemberUpdated):
+    if (
+        event.chat.type == "private"
+        and event.new_chat_member.status == "member"
+        and event.old_chat_member.status in {"kicked", "left"}
+    ):
+        session = SessionLocal()
+        user = ensure_user(session, event.from_user.id)
+        user.left_bot = False
+        session.commit()
+        session.close()
+        from ..alerts import user_unblocked as alert_user_unblocked
+
+        await alert_user_unblocked(event.from_user.id)
 
 
 async def back_to_menu(message: types.Message):
@@ -146,3 +167,4 @@ def register(dp: Dispatcher):
     )
     dp.callback_query.register(cb_menu, F.data == "menu")
     dp.my_chat_member.register(on_user_left)
+    dp.my_chat_member.register(on_user_unblocked)

--- a/bot/texts.py
+++ b/bot/texts.py
@@ -276,6 +276,7 @@ ADMIN_STATS = (
     "Пробная PRO: {trial_pro}\n"
     "Пробная Старт: {trial_light}\n"
     "Free с запросами: {used}\n"
+    "Вышли из бота: {left}\n"
     "Запросы за сегодня: {req_today}"
 )
 BTN_FEATURES = "Функционал"


### PR DESCRIPTION
## Summary
- track users who leave the bot and send unblocked alerts when they return
- add `left_bot` flag and show count of departed users in admin stats

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68926d4c1d8c832e96a65c6cbece4a65