### PR TITLE
Track last request and daily usage on subscriptions

### DIFF
--- a/bot/subscriptions.py
+++ b/bot/subscriptions.py
@@ -173,8 +173,6 @@ def consume_request(session: SessionLocal, user: User) -> tuple[bool, str]:
         blocked = True
     if user.monthly_used == 800:
         asyncio.create_task(alert_monthly_limit(user.telegram_id))
-    from .database import RequestLog
-    session.add(RequestLog(user_id=user.id))
     session.commit()
     if blocked:
         asyncio.create_task(user_blocked_daily(user.telegram_id))


### PR DESCRIPTION
## Summary
- add `last_request` field to subscriptions and expose it on the user model
- use subscription timestamps for engagement and inactivity reminders
- replace request log with subscription counters in daily stats and admin metrics

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68927eb6110c832e87071b50224090e6