### PR TITLE
refactor: remove legacy request_logs

### DIFF
--- a/bot/database.py
+++ b/bot/database.py
@@ -61,6 +61,12 @@ def _ensure_columns():
             conn.execute(text("ALTER TABLE subscriptions ADD COLUMN last_request TIMESTAMP"))
 
 
+def _drop_request_logs():
+    """Remove legacy request_logs table if it still exists."""
+    with engine.begin() as conn:
+        conn.execute(text("DROP TABLE IF EXISTS request_logs"))
+
+
 class User(Base):
     __tablename__ = 'users'
     id = Column(Integer, primary_key=True)
@@ -364,5 +370,6 @@ def _ensure_cascades():
 
 Base.metadata.create_all(engine)
 _ensure_columns()
+_drop_request_logs()
 _ensure_options()
 _ensure_cascades()


### PR DESCRIPTION
## Summary
- ensure old `request_logs` table is dropped on startup

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_6892849f4ea8832eba0d6c0f601f593a