### PR TITLE
feat: anchor pending reminder to last analysis

### DIFF
--- a/bot/engagement.py
+++ b/bot/engagement.py
@@ -74,7 +74,20 @@ async def process_request_events(bot: Bot, telegram_id: int) -> None:
         and session.query(Meal).filter_by(user_id=user.id).count() == 0
     ):
         try:
-            await bot.send_message(user.telegram_id, NO_MEAL_AFTER_REQUESTS)
+            meals = [
+                m
+                for m in pending_meals.values()
+                if m.get("chat_id") == user.telegram_id and m.get("message_id")
+            ]
+            msg_id = None
+            if meals:
+                latest = max(meals, key=lambda m: m.get("timestamp", 0))
+                msg_id = latest.get("message_id")
+            await bot.send_message(
+                user.telegram_id,
+                NO_MEAL_AFTER_REQUESTS,
+                reply_to_message_id=msg_id,
+            )
         except Exception:
             pass
         eng.five_no_meal_sent = True

--- a/bot/handlers/manual.py
+++ b/bot/handlers/manual.py
@@ -139,13 +139,13 @@ async def process_manual(message: types.Message, state: FSMContext):
         return
     grade = user.grade
     session.close()
-    asyncio.create_task(process_request_events(message.bot, message.from_user.id))
 
     results = await analyze_text(message.text, grade=grade)
     log("prompt", "text analyzed for %s", message.from_user.id)
     if isinstance(results, list) and results and results[0].get("error"):
         await message.answer(MANUAL_ERROR)
         log("prompt", "manual text not recognized for %s", message.from_user.id)
+        asyncio.create_task(process_request_events(message.bot, message.from_user.id))
         return
     if not isinstance(results, list):
         results = [results]
@@ -153,6 +153,7 @@ async def process_manual(message: types.Message, state: FSMContext):
     if not valid:
         await message.answer(MANUAL_ERROR)
         log("prompt", "manual text not recognized for %s", message.from_user.id)
+        asyncio.create_task(process_request_events(message.bot, message.from_user.id))
         return
 
     for idx, res in enumerate(valid, 1):
@@ -222,6 +223,7 @@ async def process_manual(message: types.Message, state: FSMContext):
         pending_meals[meal_id]["message_id"] = msg.message_id
         pending_meals[meal_id]["chat_id"] = msg.chat.id
     await state.clear()
+    asyncio.create_task(process_request_events(message.bot, message.from_user.id))
 
 
 def register(dp: Dispatcher):

--- a/bot/handlers/photo.py
+++ b/bot/handlers/photo.py
@@ -126,7 +126,6 @@ async def handle_photo(message: types.Message, state: FSMContext):
         return
     grade = user.grade
     session.close()
-    asyncio.create_task(process_request_events(message.bot, message.from_user.id))
 
     processing_msg = await message.reply(PHOTO_ANALYZING)
     photo = message.photo[-1]
@@ -147,6 +146,7 @@ async def handle_photo(message: types.Message, state: FSMContext):
     log("prompt", "photo analyzed for %s", message.from_user.id)
     if isinstance(results, list) and results and results[0].get("error"):
         await processing_msg.edit_text(RECOGNITION_ERROR)
+        asyncio.create_task(process_request_events(message.bot, message.from_user.id))
         return
     if not isinstance(results, list):
         results = [results]
@@ -155,6 +155,7 @@ async def handle_photo(message: types.Message, state: FSMContext):
     all_names = [r.get("name") for r in valid if r.get("name")]
     if not valid:
         await processing_msg.edit_text(NO_FOOD_ERROR)
+        asyncio.create_task(process_request_events(message.bot, message.from_user.id))
         return
 
     for idx, res in enumerate(valid, 1):
@@ -247,6 +248,8 @@ async def handle_photo(message: types.Message, state: FSMContext):
             )
             pending_meals[meal_id]["message_id"] = msg.message_id
             pending_meals[meal_id]["chat_id"] = msg.chat.id
+
+    asyncio.create_task(process_request_events(message.bot, message.from_user.id))
 
 
 async def handle_document(message: types.Message):


### PR DESCRIPTION
## Summary
- link reminder about confirming results to the user's latest analysis message
- schedule engagement checks after analysis messages are sent

## Testing
- `python -m py_compile bot/engagement.py bot/handlers/manual.py bot/handlers/photo.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68927dbc602c832e88d503214c6a4459