### PR TITLE
Show user start date in admin panel

### DIFF
--- a/bot/handlers/admin.py
+++ b/bot/handlers/admin.py
@@ -101,6 +101,7 @@ def build_user_info(session: SessionLocal, user: User) -> str:
         sub = f"платный ({grade_title(user.grade)})"
     return (
         f"ID: {user.telegram_id}\n"
+        f"Дата старта: {user.created_at.date()}\n"
         f"Текущая подписка: {sub}\n"
         f"Остаток дней по текущей подписке: {days if days is not None else '-'}\n"
         f"Замороженная подписка: {frozen}\n"


### PR DESCRIPTION
## Summary
- Display user start date in admin panel user details

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894e8ec6d14832ebadbaa6fad234116