### PR TITLE
Add free without requests stat to admin panel

### DIFF
--- a/bot/handlers/admin.py
+++ b/bot/handlers/admin.py
@@ -509,6 +509,12 @@ async def admin_stats(query: types.CallbackQuery):
         .filter(Subscription.grade == "free", Subscription.requests_used > 0)
         .count()
     )
+    unused = (
+        session.query(User)
+        .join(Subscription)
+        .filter(Subscription.grade == "free", Subscription.requests_used == 0)
+        .count()
+    )
     left = session.query(User).filter_by(left_bot=True).count()
     start_today = now.replace(hour=0, minute=0, second=0, microsecond=0)
     q_today = (
@@ -525,6 +531,7 @@ async def admin_stats(query: types.CallbackQuery):
         trial_pro=trial_pro,
         trial_light=trial_light,
         used=used,
+        unused=unused,
         left=left,
         req_today=q_today,
     )

--- a/bot/texts.py
+++ b/bot/texts.py
@@ -312,6 +312,7 @@ ADMIN_STATS = (
     "Пробная PRO: {trial_pro}\n"
     "Пробная Старт: {trial_light}\n"
     "Free с запросами: {used}\n"
+    "Free без запросов: {unused}\n"
     "Вышли из бота: {left}\n"
     "Запросы за сегодня: {req_today}"
 )


### PR DESCRIPTION
## Summary
- include count of free users without requests in admin stats

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689525b63fe8832ebec21d66834fb0dd