### PR TITLE
Add back button to goal start keyboard

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -424,6 +424,7 @@ def reminders_settings_kb(user) -> InlineKeyboardMarkup:
 def goal_start_kb() -> InlineKeyboardMarkup:
     builder = InlineKeyboardBuilder()
     builder.button(text=BTN_GOAL_START, callback_data="goal_start")
+    builder.button(text=BTN_BACK, callback_data="stats_menu")
     builder.adjust(1)
     return builder.as_markup()
 

--- a/tests/test_goal_start_keyboard.py
+++ b/tests/test_goal_start_keyboard.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot.keyboards import goal_start_kb  # noqa: E402
+from bot.texts import BTN_GOAL_START, BTN_BACK  # noqa: E402
+
+
+def test_goal_start_keyboard_structure():
+    kb = goal_start_kb()
+    inline_keyboard = kb.inline_keyboard
+    assert len(inline_keyboard) == 2
+    assert inline_keyboard[0][0].text == BTN_GOAL_START
+    assert inline_keyboard[0][0].callback_data == "goal_start"
+    assert inline_keyboard[1][0].text == BTN_BACK
+    assert inline_keyboard[1][0].callback_data == "stats_menu"


### PR DESCRIPTION
## Summary
- Add back button to goal start keyboard to allow returning to stats
- Cover goal start keyboard with test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc9cf78d60832e90d9ccc21128f70e