### PR TITLE
Improve goal creation flow and fix save and stop handlers

### DIFF
--- a/bot/handlers/goals.py
+++ b/bot/handlers/goals.py
@@ -110,8 +110,8 @@ async def goal_cancel(query: types.CallbackQuery, state: FSMContext):
 
 async def goal_set_gender(query: types.CallbackQuery, state: FSMContext):
     value = query.data.split(":")[1]
-    await state.update_data(gender=value)
     await query.message.edit_text(GOAL_ENTER_AGE, reply_markup=goal_back_kb("gender"))
+    await state.update_data(gender=value, msg_id=query.message.message_id)
     await state.set_state(GoalState.age)
     await query.answer()
 
@@ -125,8 +125,19 @@ async def process_age(message: types.Message, state: FSMContext):
     if not 14 <= age <= 100:
         await message.answer(INPUT_RANGE_ERROR)
         return
+    data = await state.get_data()
+    msg_id = data.get("msg_id")
     await state.update_data(age=age)
-    await message.answer(GOAL_ENTER_HEIGHT, reply_markup=goal_back_kb("age"))
+    await message.delete()
+    if msg_id:
+        await message.bot.edit_message_text(
+            GOAL_ENTER_HEIGHT,
+            chat_id=message.chat.id,
+            message_id=msg_id,
+            reply_markup=goal_back_kb("age"),
+        )
+    else:
+        await message.answer(GOAL_ENTER_HEIGHT, reply_markup=goal_back_kb("age"))
     await state.set_state(GoalState.height)
 
 
@@ -139,8 +150,19 @@ async def process_height(message: types.Message, state: FSMContext):
     if not 120 <= height <= 230:
         await message.answer(INPUT_RANGE_ERROR)
         return
+    data = await state.get_data()
+    msg_id = data.get("msg_id")
     await state.update_data(height=height)
-    await message.answer(GOAL_ENTER_WEIGHT, reply_markup=goal_back_kb("height"))
+    await message.delete()
+    if msg_id:
+        await message.bot.edit_message_text(
+            GOAL_ENTER_WEIGHT,
+            chat_id=message.chat.id,
+            message_id=msg_id,
+            reply_markup=goal_back_kb("height"),
+        )
+    else:
+        await message.answer(GOAL_ENTER_WEIGHT, reply_markup=goal_back_kb("height"))
     await state.set_state(GoalState.weight)
 
 
@@ -153,8 +175,10 @@ async def process_weight(message: types.Message, state: FSMContext):
     if not 35 <= weight <= 300:
         await message.answer(INPUT_RANGE_ERROR)
         return
-    await state.update_data(weight=weight)
     data = await state.get_data()
+    msg_id = data.get("msg_id")
+    await state.update_data(weight=weight)
+    await message.delete()
     if data.get("editing"):
         session = SessionLocal()
         user = ensure_user(session, message.from_user.id)
@@ -164,9 +188,25 @@ async def process_weight(message: types.Message, state: FSMContext):
         session.commit()
         session.close()
         await state.clear()
-        await message.answer(GOAL_EDIT_PROMPT, reply_markup=goal_edit_kb())
+        if msg_id:
+            await message.bot.edit_message_text(
+                GOAL_EDIT_PROMPT,
+                chat_id=message.chat.id,
+                message_id=msg_id,
+                reply_markup=goal_edit_kb(),
+            )
+        else:
+            await message.answer(GOAL_EDIT_PROMPT, reply_markup=goal_edit_kb())
     else:
-        await message.answer(GOAL_CHOOSE_ACTIVITY, reply_markup=goal_activity_kb())
+        if msg_id:
+            await message.bot.edit_message_text(
+                GOAL_CHOOSE_ACTIVITY,
+                chat_id=message.chat.id,
+                message_id=msg_id,
+                reply_markup=goal_activity_kb(),
+            )
+        else:
+            await message.answer(GOAL_CHOOSE_ACTIVITY, reply_markup=goal_activity_kb())
         await state.set_state(GoalState.activity)
 
 
@@ -231,15 +271,19 @@ async def goal_back(query: types.CallbackQuery, state: FSMContext):
         await goal_start(query, state)
     elif step == "age":
         await query.message.edit_text(GOAL_ENTER_AGE, reply_markup=goal_back_kb("gender"))
+        await state.update_data(msg_id=query.message.message_id)
         await state.set_state(GoalState.age)
     elif step == "height":
         await query.message.edit_text(GOAL_ENTER_HEIGHT, reply_markup=goal_back_kb("age"))
+        await state.update_data(msg_id=query.message.message_id)
         await state.set_state(GoalState.height)
     elif step == "weight":
         await query.message.edit_text(GOAL_ENTER_WEIGHT, reply_markup=goal_back_kb("height"))
+        await state.update_data(msg_id=query.message.message_id)
         await state.set_state(GoalState.weight)
     elif step == "activity":
         await query.message.edit_text(GOAL_CHOOSE_ACTIVITY, reply_markup=goal_activity_kb())
+        await state.update_data(msg_id=query.message.message_id)
         await state.set_state(GoalState.activity)
     elif step == "edit":
         await state.clear()
@@ -262,9 +306,11 @@ async def goal_confirm_save(query: types.CallbackQuery, state: FSMContext):
     goal.target = data.get("target")
     goal.calories, goal.protein, goal.fat, goal.carbs = cal, p, f, c
     session.commit()
+    session.refresh(goal)
+    summary = goal_summary_text(goal)
     session.close()
     await state.clear()
-    await query.message.edit_text(goal_summary_text(goal), reply_markup=goals_main_kb())
+    await query.message.edit_text(summary, reply_markup=goals_main_kb())
     await query.answer()
 
 
@@ -282,7 +328,7 @@ async def goal_edit_menu(query: types.CallbackQuery):
 
 async def goal_edit_param(query: types.CallbackQuery, state: FSMContext):
     param = query.data.split(":")[1]
-    await state.update_data(editing=True)
+    await state.update_data(editing=True, msg_id=query.message.message_id)
     if param == "weight":
         await query.message.edit_text(GOAL_ENTER_WEIGHT, reply_markup=goal_back_kb("edit"))
         await state.set_state(GoalState.weight)
@@ -386,7 +432,11 @@ async def goal_stop_confirm(query: types.CallbackQuery):
         session.delete(user.goal)
         session.commit()
     session.close()
-    await query.message.edit_text(GOAL_STOP_DONE, reply_markup=main_menu_kb())
+    try:
+        await query.message.delete()
+    except Exception:
+        pass
+    await query.message.answer(GOAL_STOP_DONE, reply_markup=main_menu_kb())
     await query.answer()
 
 

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -424,6 +424,7 @@ def reminders_settings_kb(user) -> InlineKeyboardMarkup:
 def goal_start_kb() -> InlineKeyboardMarkup:
     builder = InlineKeyboardBuilder()
     builder.button(text=BTN_GOAL_START, callback_data="goal_start")
+    builder.button(text=BTN_BACK, callback_data="stats_menu")
     builder.adjust(1)
     return builder.as_markup()
 

--- a/tests/test_goal_process_input.py
+++ b/tests/test_goal_process_input.py
@@ -1,0 +1,69 @@
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ensure database URL for handlers import
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot.handlers.goals import process_age, process_weight, GoalState  # noqa: E402
+from bot.keyboards import goal_back_kb, goal_activity_kb  # noqa: E402
+from bot.texts import GOAL_ENTER_HEIGHT, GOAL_CHOOSE_ACTIVITY  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_process_age_edits_prompt_and_deletes_input():
+    message = MagicMock()
+    message.text = "25"
+    message.chat.id = 1
+    message.delete = AsyncMock()
+    message.answer = AsyncMock()
+    bot = MagicMock()
+    bot.edit_message_text = AsyncMock()
+    message.bot = bot
+
+    state = AsyncMock()
+    state.get_data.return_value = {"msg_id": 42}
+
+    await process_age(message, state)
+
+    message.delete.assert_awaited_once()
+    bot.edit_message_text.assert_awaited_once_with(
+        GOAL_ENTER_HEIGHT,
+        chat_id=1,
+        message_id=42,
+        reply_markup=goal_back_kb("age"),
+    )
+    message.answer.assert_not_called()
+    state.set_state.assert_awaited_once_with(GoalState.height)
+
+
+@pytest.mark.asyncio
+async def test_process_weight_moves_to_activity_and_deletes_input():
+    message = MagicMock()
+    message.text = "70"
+    message.chat.id = 1
+    message.delete = AsyncMock()
+    message.answer = AsyncMock()
+    bot = MagicMock()
+    bot.edit_message_text = AsyncMock()
+    message.bot = bot
+
+    state = AsyncMock()
+    state.get_data.return_value = {"msg_id": 99}
+
+    await process_weight(message, state)
+
+    message.delete.assert_awaited_once()
+    bot.edit_message_text.assert_awaited_once_with(
+        GOAL_CHOOSE_ACTIVITY,
+        chat_id=1,
+        message_id=99,
+        reply_markup=goal_activity_kb(),
+    )
+    message.answer.assert_not_called()
+    state.set_state.assert_awaited_once_with(GoalState.activity)

--- a/tests/test_goal_start_keyboard.py
+++ b/tests/test_goal_start_keyboard.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot.keyboards import goal_start_kb  # noqa: E402
+from bot.texts import BTN_GOAL_START, BTN_BACK  # noqa: E402
+
+
+def test_goal_start_keyboard_structure():
+    kb = goal_start_kb()
+    inline_keyboard = kb.inline_keyboard
+    assert len(inline_keyboard) == 2
+    assert inline_keyboard[0][0].text == BTN_GOAL_START
+    assert inline_keyboard[0][0].callback_data == "goal_start"
+    assert inline_keyboard[1][0].text == BTN_BACK
+    assert inline_keyboard[1][0].callback_data == "stats_menu"

--- a/tests/test_goal_stop_confirm.py
+++ b/tests/test_goal_stop_confirm.py
@@ -1,0 +1,42 @@
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot.handlers import goals  # noqa: E402
+from bot.keyboards import main_menu_kb  # noqa: E402
+from bot.texts import GOAL_STOP_DONE  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_goal_stop_confirm_sends_main_menu_keyboard(monkeypatch):
+    session = MagicMock()
+    monkeypatch.setattr(goals, "SessionLocal", MagicMock(return_value=session))
+    user = MagicMock()
+    user.goal = object()
+    monkeypatch.setattr(goals, "ensure_user", MagicMock(return_value=user))
+
+    message = MagicMock()
+    message.delete = AsyncMock()
+    message.answer = AsyncMock()
+    message.edit_text = AsyncMock()
+
+    query = MagicMock()
+    query.from_user.id = 1
+    query.message = message
+    query.answer = AsyncMock()
+
+    await goals.goal_stop_confirm(query)
+
+    message.delete.assert_awaited_once()
+    message.answer.assert_awaited_once_with(GOAL_STOP_DONE, reply_markup=main_menu_kb())
+    message.edit_text.assert_not_called()
+    session.delete.assert_called_once_with(user.goal)
+    session.commit.assert_called_once()
+    session.close.assert_called_once()
+    query.answer.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Delete user messages and edit the same bot prompt during age, height and weight entry
- Refresh goal instance before summarizing to prevent DetachedInstanceError
- Add tests ensuring manual input prompts are updated in place
- Provide back navigation from goal start
- Fix goal stop confirmation to send main menu keyboard

## Testing
- `pip install pytest-asyncio -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc9cf78d60832e90d9ccc21128f70e