### PR TITLE
Add goal progress warnings, dynamic summaries, and trends

### DIFF
--- a/bot/handlers/goals.py
+++ b/bot/handlers/goals.py
@@ -3,7 +3,7 @@ from aiogram.fsm.context import FSMContext
 from aiogram.filters import StateFilter
 from aiogram.exceptions import TelegramBadRequest
 
-from ..database import SessionLocal, Goal, get_option_bool
+from ..database import SessionLocal, Goal, Meal, get_option_bool
 from ..subscriptions import ensure_user
 from ..keyboards import (
     goal_start_kb,
@@ -46,6 +46,7 @@ from ..texts import (
     FEATURE_DISABLED,
 )
 from datetime import datetime, timedelta
+from sqlalchemy import func
 
 
 def calculate_goal(data: dict) -> tuple[int, int, int, int]:
@@ -110,6 +111,77 @@ def goal_summary_text(goal: Goal) -> str:
         p_eaten=p_eaten,
         f_eaten=f_eaten,
         c_eaten=c_eaten,
+    )
+
+
+def goal_progress_text(goal: Goal, totals: dict) -> str:
+    """Return dynamic progress card text after saving a meal."""
+    cal = int(totals.get("calories", 0))
+    p = int(totals.get("protein", 0))
+    f = int(totals.get("fat", 0))
+    c = int(totals.get("carbs", 0))
+    remain = (goal.calories or 0) - cal
+    lines = [
+        "📊 Текущий прогресс",
+        f"Ккал: {cal} / {goal.calories or 0} (осталось {remain})",
+    ]
+    pct = lambda val, goal_val: int(val / goal_val * 100) if goal_val else 0
+    lines.append(
+        f"Б: {pct(p, goal.protein)}% • Ж: {pct(f, goal.fat)}% • У: {pct(c, goal.carbs)}%"
+    )
+    if goal.calories:
+        ratio = cal / goal.calories
+        if ratio > 1.10:
+            lines.append(f"Превышение на {cal - goal.calories} ккал")
+        elif ratio < 0.90:
+            lines.append(
+                "До цели {dc} ккал и {dp} б, {df} ж, {du} у".format(
+                    dc=goal.calories - cal,
+                    dp=max(0, goal.protein - p),
+                    df=max(0, goal.fat - f),
+                    du=max(0, goal.carbs - c),
+                )
+            )
+    return "\n".join(lines)
+
+
+def goal_trends_report(user, days: int, session) -> str:
+    """Return trend statistics for the given user over ``days`` days."""
+    goal = getattr(user, "goal", None)
+    if not goal:
+        return GOAL_TRENDS.format(
+            days=days, balance=0, p=0, p_goal=0, f=0, f_goal=0, c=0, c_goal=0
+        )
+    start = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+    start -= timedelta(days=days - 1)
+    end = start + timedelta(days=days)
+    totals = session.query(
+        func.coalesce(func.sum(Meal.calories), 0),
+        func.coalesce(func.sum(Meal.protein), 0),
+        func.coalesce(func.sum(Meal.fat), 0),
+        func.coalesce(func.sum(Meal.carbs), 0),
+        func.count(func.distinct(func.date(Meal.timestamp))),
+    ).filter(
+        Meal.user_id == user.id,
+        Meal.timestamp >= start,
+        Meal.timestamp < end,
+    ).one()
+    total_cal, total_p, total_f, total_c, day_count = totals
+    denom = day_count or 1
+    avg_cal = total_cal / denom
+    avg_p = total_p / denom
+    avg_f = total_f / denom
+    avg_c = total_c / denom
+    balance = int(round(avg_cal - (goal.calories or 0)))
+    return GOAL_TRENDS.format(
+        days=days,
+        balance=balance,
+        p=int(avg_p),
+        p_goal=int(goal.protein or 0),
+        f=int(avg_f),
+        f_goal=int(goal.fat or 0),
+        c=int(avg_c),
+        c_goal=int(goal.carbs or 0),
     )
 
 
@@ -446,11 +518,6 @@ async def goal_restart(query: types.CallbackQuery, state: FSMContext):
     await query.answer()
 
 
-async def goal_edit_menu(query: types.CallbackQuery):
-    await query.message.edit_text(GOAL_EDIT_PROMPT, reply_markup=goal_edit_kb())
-    await query.answer()
-
-
 async def goal_edit_param(query: types.CallbackQuery, state: FSMContext):
     param = query.data.split(":")[1]
     await state.update_data(editing=True, msg_id=query.message.message_id)
@@ -499,8 +566,11 @@ async def goal_recalc(query: types.CallbackQuery):
 
 async def goal_trends(query: types.CallbackQuery):
     days = int(query.data.split(":")[1])
-    text = GOAL_TRENDS.format(days=days, balance=0, p=0, p_goal=0, f=0, f_goal=0, c=0, c_goal=0)
+    session = SessionLocal()
+    user = ensure_user(session, query.from_user.id)
+    text = goal_trends_report(user, days, session)
     await query.message.edit_text(text, reply_markup=goal_trends_kb(days))
+    session.close()
     await query.answer()
 
 
@@ -598,7 +668,6 @@ def register(dp: Dispatcher):
     dp.callback_query.register(goal_back, F.data.startswith("goal_back:"))
     dp.callback_query.register(goal_confirm_save, F.data == "goal_save")
     dp.callback_query.register(goal_restart, F.data == "goal_restart")
-    dp.callback_query.register(goal_edit_menu, F.data == "goal_edit_menu")
     dp.callback_query.register(goal_edit_param, F.data.startswith("goal_edit:"))
     dp.callback_query.register(goal_recalc, F.data == "goal_recalc")
     dp.callback_query.register(goal_trends, F.data.startswith("goal_trends:"))

--- a/bot/handlers/manual.py
+++ b/bot/handlers/manual.py
@@ -222,7 +222,9 @@ async def process_manual(message: types.Message, state: FSMContext):
             await state.set_state(EditMeal.waiting_input)
             continue
         msg = await message.answer(
-            format_meal_message(name, serving, macros),
+            format_meal_message(
+                name, serving, macros, user_id=message.from_user.id
+            ),
             reply_markup=meal_actions_kb(meal_id),
         )
         pending_meals[meal_id]["message_id"] = msg.message_id

--- a/bot/handlers/photo.py
+++ b/bot/handlers/photo.py
@@ -243,14 +243,18 @@ async def handle_photo(message: types.Message, state: FSMContext):
 
         if idx == 1:
             await processing_msg.edit_text(
-                format_meal_message(name, serving, macros),
+                format_meal_message(
+                    name, serving, macros, user_id=message.from_user.id
+                ),
                 reply_markup=meal_actions_kb(meal_id),
             )
             pending_meals[meal_id]["message_id"] = processing_msg.message_id
             pending_meals[meal_id]["chat_id"] = processing_msg.chat.id
         else:
             msg = await message.answer(
-                format_meal_message(name, serving, macros),
+                format_meal_message(
+                    name, serving, macros, user_id=message.from_user.id
+                ),
                 reply_markup=meal_actions_kb(meal_id),
             )
             pending_meals[meal_id]["message_id"] = msg.message_id

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -75,7 +75,6 @@ from .texts import (
     BTN_GAIN_PROTEIN_CARB,
     BTN_GOAL_SAVE,
     BTN_GOAL_RESTART,
-    BTN_MY_GOAL,
     BTN_TRENDS,
     BTN_GOAL_REMINDERS,
     BTN_WEIGHT,
@@ -524,7 +523,6 @@ def goal_confirm_kb() -> InlineKeyboardMarkup:
 
 def goals_main_kb() -> InlineKeyboardMarkup:
     builder = InlineKeyboardBuilder()
-    builder.button(text=BTN_MY_GOAL, callback_data="goal_edit_menu")
     builder.button(text=BTN_TRENDS, callback_data="goal_trends:7")
     builder.button(text=BTN_GOAL_REMINDERS, callback_data="goal_reminders")
     builder.button(text=BTN_GOAL_STOP, callback_data="goal_stop")
@@ -579,5 +577,12 @@ def goal_stop_confirm_kb() -> InlineKeyboardMarkup:
     builder = InlineKeyboardBuilder()
     builder.button(text=BTN_STOP_CONFIRM, callback_data="goal_stop_confirm")
     builder.button(text=BTN_BACK, callback_data="goals_main")
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+def goal_progress_kb() -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.button(text=BTN_TRENDS, callback_data="goal_trends:7")
     builder.adjust(1)
     return builder.as_markup()

--- a/bot/texts.py
+++ b/bot/texts.py
@@ -164,7 +164,6 @@ BTN_GAIN_BALANCED = "⚖️ Сбалансированное"
 BTN_GAIN_PROTEIN_CARB = "🥩 Белково-углеводное"
 BTN_GOAL_SAVE = "✅ Сохранить"
 BTN_GOAL_RESTART = "✏️Начать сначала"
-BTN_MY_GOAL = "📝 Моя цель"
 BTN_TRENDS = "📈 Тенденции"
 BTN_GOAL_REMINDERS = "⏰ Напоминания"
 BTN_WEIGHT = "⚖️ Вес"
@@ -299,7 +298,7 @@ GOAL_REMIND_FIRST_EVENING = (
     "🌙 Первый день подходит к концу.\nТвоя цель была: {kcal} ккал\nБ: {p} г • Ж: {f} г • У: {c} г\nДаже если не всё отметил — это начало. Завтра продолжим 👣"
 )
 
-GOAL_REMIND_KB = "📈 Тенденции | 🎯 Моя цель | ⚙️ Напоминания"
+GOAL_REMIND_KB = "📈 Тенденции | ⚙️ Напоминания"
 
 DEV_FEATURE = "🤖 Функционал в разработке"
 FEATURE_DISABLED = "🤖 Функционал временно недоступен"

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -1,14 +1,22 @@
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 import re
+
+from datetime import datetime, timedelta
+from sqlalchemy import func
 
 from .texts import MEAL_TEMPLATE
 from .logger import log
+from .database import SessionLocal, User, Meal
 
 
 def format_meal_message(
-    name: str, serving: float, macros: Dict[str, float]
+    name: str, serving: float, macros: Dict[str, float], user_id: Optional[int] = None
 ) -> str:
-    """Format meal info using the new template."""
+    """Format meal info using the new template.
+
+    If ``user_id`` is provided and the user has an active goal, a warning is
+    appended when the given meal would push the user over the daily goal.
+    """
     log("utils", f"Formatting meal message for {name}")
     message = MEAL_TEMPLATE.format(
         name=name,
@@ -18,6 +26,38 @@ def format_meal_message(
         fat=macros["fat"],
         carbs=macros["carbs"],
     )
+
+    if user_id is not None:
+        session = SessionLocal()
+        user = session.query(User).filter_by(telegram_id=user_id).first()
+        if user and user.goal and user.goal.calories:
+            start = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+            end = start + timedelta(days=1)
+            totals = session.query(
+                func.coalesce(func.sum(Meal.calories), 0),
+                func.coalesce(func.sum(Meal.protein), 0),
+                func.coalesce(func.sum(Meal.fat), 0),
+                func.coalesce(func.sum(Meal.carbs), 0),
+            ).filter(
+                Meal.user_id == user.id,
+                Meal.timestamp >= start,
+                Meal.timestamp < end,
+            ).one()
+            cal_forecast = totals[0] + macros["calories"]
+            p_forecast = totals[1] + macros["protein"]
+            f_forecast = totals[2] + macros["fat"]
+            c_forecast = totals[3] + macros["carbs"]
+            cal_ex = max(0, round(cal_forecast - (user.goal.calories or 0), 1))
+            p_ex = max(0, round(p_forecast - (user.goal.protein or 0), 1))
+            f_ex = max(0, round(f_forecast - (user.goal.fat or 0), 1))
+            c_ex = max(0, round(c_forecast - (user.goal.carbs or 0), 1))
+            if cal_ex or p_ex or f_ex or c_ex:
+                message += (
+                    "\n\n"
+                    f"⚠️ Добавив это блюдо, ты превысишь дневную цель на "
+                    f"{int(cal_ex)} ккал и {int(p_ex)} б, {int(f_ex)} ж, {int(c_ex)} у"
+                )
+        session.close()
     log("utils", f"Formatted meal message: {message}")
     return message
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest_plugins = ("pytest_asyncio",)

--- a/tests/test_goal_notifications.py
+++ b/tests/test_goal_notifications.py
@@ -1,0 +1,33 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot.database import Base, engine, SessionLocal, User, Goal  # noqa: E402
+from bot.utils import format_meal_message  # noqa: E402
+from bot.handlers.goals import goal_progress_text  # noqa: E402
+
+
+Base.metadata.create_all(bind=engine)
+
+
+def test_format_meal_message_warns_on_goal_exceed():
+    session = SessionLocal()
+    user = User(telegram_id=1)
+    user.goal = Goal(calories=100, protein=10, fat=5, carbs=10)
+    session.add(user)
+    session.commit()
+    macros = {"calories": 200, "protein": 20, "fat": 10, "carbs": 15}
+    text = format_meal_message("Test", 100, macros, user_id=1)
+    assert "превысишь дневную цель" in text
+    session.close()
+
+
+def test_goal_progress_text_outputs_expected_lines():
+    goal = Goal(calories=2000, protein=150, fat=60, carbs=250)
+    totals = {"calories": 2300, "protein": 160, "fat": 70, "carbs": 260}
+    text = goal_progress_text(goal, totals)
+    assert "Превышение на 300 ккал" in text

--- a/tests/test_goal_trends.py
+++ b/tests/test_goal_trends.py
@@ -1,0 +1,61 @@
+import os
+import sys
+from pathlib import Path
+from datetime import datetime, timedelta
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot.database import Base, engine, SessionLocal, User, Goal, Meal  # noqa: E402
+from bot.handlers.goals import goal_trends_report  # noqa: E402
+
+
+Base.metadata.create_all(bind=engine)
+
+
+def test_goal_trends_report_averages_meals():
+    session = SessionLocal()
+    user = User(telegram_id=999)
+    session.add(user)
+    session.commit()
+    goal = Goal(user_id=user.id, calories=2000, protein=100, fat=70, carbs=250)
+    user.goal = goal
+    session.add(goal)
+    session.commit()
+    now = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+    meal1 = Meal(
+        user_id=user.id,
+        name="m1",
+        ingredients="",
+        serving=100,
+        calories=1800,
+        protein=90,
+        fat=60,
+        carbs=200,
+        timestamp=now - timedelta(days=1),
+    )
+    meal2 = Meal(
+        user_id=user.id,
+        name="m2",
+        ingredients="",
+        serving=100,
+        calories=2200,
+        protein=110,
+        fat=80,
+        carbs=260,
+        timestamp=now,
+    )
+    session.add_all([meal1, meal2])
+    session.commit()
+    text = goal_trends_report(user, 7, session)
+    assert text == (
+        "📊 Тенденции за 7 дней\n"
+        "— Средний баланс: 0 ккал/день\n"
+        "— Белки: 100 от цели 100\n"
+        "— Жиры: 70 от цели 70\n"
+        "— Углеводы: 230 от цели 250\n"
+        "Продолжай! 💪"
+    )
+    session.close()
+


### PR DESCRIPTION
## Summary
- compute multi-day calorie balance and macro averages with `goal_trends_report`
- wire trend calculations into `goal_trends` handler
- add pytest-asyncio setup and test covering trend report output
- drop "My goal" button and associated callbacks from goal-related keyboards

## Testing
- `pip install pytest-asyncio`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcb7183a34832e9b3a2a51b5298d4f