### PR TITLE
Prevent assigning trials to paying users

### DIFF
--- a/bot/subscriptions.py
+++ b/bot/subscriptions.py
@@ -227,6 +227,7 @@ def process_payment_success(
     else:
         user.period_end = add_period(now, months)
     user.grade = grade
+    user.trial_used = True
     user.request_limit = PAID_LIMIT
     user.requests_used = 0
     user.notified_7d = False

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -1,0 +1,39 @@
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot import subscriptions  # noqa: E402
+
+
+class DummyUser:
+    def __init__(self):
+        self.id = 1
+        self.telegram_id = 123456789
+        self.trial = False
+        self.trial_end = None
+        self.resume_grade = None
+        self.resume_period_end = None
+        self.grade = "free"
+        self.period_end = None
+        self.request_limit = 0
+        self.requests_used = 0
+        self.notified_7d = False
+        self.notified_3d = False
+        self.notified_1d = False
+        self.notified_0d = False
+        self.goal_trial_start = None
+        self.goal_trial_notified = False
+        self.trial_used = False
+
+
+def test_process_payment_marks_trial_used():
+    user = DummyUser()
+    session = MagicMock()
+
+    subscriptions.process_payment_success(session, user, months=1, grade="light")
+
+    assert user.trial_used is True


### PR DESCRIPTION
## Summary
- mark users as having used the trial once a payment succeeds
- add a unit test ensuring payments record trial usage

## Testing
- pytest tests/test_subscriptions.py
- pytest *(fails: existing goal reminder and trend tests expect concrete datetime values when run without additional patching)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b53c12c0832ea84aeddf700ab09e