### PR TITLE
Ensure goal reminders require timezone registration

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -363,9 +363,9 @@ def back_to_reminder_settings_kb() -> InlineKeyboardMarkup:
 
 
 def back_to_goal_reminders_kb() -> InlineKeyboardMarkup:
-    """Back button returning to goal reminders screen."""
+    """Back button returning to the goals menu from reminders."""
     builder = InlineKeyboardBuilder()
-    builder.button(text=BTN_BACK, callback_data="goal_reminders")
+    builder.button(text=BTN_BACK, callback_data="goals_main")
     builder.adjust(1)
     return builder.as_markup()
 


### PR DESCRIPTION
## Summary
- require users to register their timezone before opening goal reminders and persist the return target in FSM state
- reuse the timezone update flow so goal reminders return to the correct screen and adjust the back button to the goals menu
- extend the goal reminder tests to cover timezone prompting and navigation after timezone updates

## Testing
- pytest *(fails: missing pytest_asyncio)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b61c252c832ea844dc9d41c1c00b