### PR TITLE
Move goals button to top of stats menu

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -325,10 +325,10 @@ def stats_menu_inline_kb() -> InlineKeyboardMarkup:
     from .database import get_option_bool
 
     builder = InlineKeyboardBuilder()
-    builder.button(text=BTN_REPORT_DAY, callback_data="report_day")
-    builder.button(text=BTN_MY_MEALS, callback_data="my_meals")
     if get_option_bool("feat_goals"):
         builder.button(text=BTN_GOALS, callback_data="goals")
+    builder.button(text=BTN_REPORT_DAY, callback_data="report_day")
+    builder.button(text=BTN_MY_MEALS, callback_data="my_meals")
     builder.button(text=BTN_BACK, callback_data="menu")
     builder.adjust(1)
     return builder.as_markup()


### PR DESCRIPTION
## Summary
- place the nutrition goals button at the top of the statistics menu keyboard so it appears first

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cb0112a1b4832e803c75980df56a57