### PR TITLE
Align subscription expiry reminders with payment time

### DIFF
--- a/bot/subscriptions.py
+++ b/bot/subscriptions.py
@@ -421,19 +421,19 @@ async def _daily_check(bot: Bot):
                     pass
                 user.notified_0d = True
         if user.grade in {"light", "pro"} and user.period_end and not user.trial:
-            days = (user.period_end.date() - now.date()).days
+            delta = user.period_end - now
             text = None
             price = PLAN_PRICES["1m"] if user.grade == "light" else PRO_PLAN_PRICES["1m"]
-            if days <= 0 and not user.notified_0d:
+            if delta <= timedelta(0) and not user.notified_0d:
                 text = SUB_PAUSED.format(price=price)
                 user.notified_0d = True
-            elif days == 1 and not user.notified_1d:
+            elif delta <= timedelta(days=1) and not user.notified_1d:
                 text = SUB_END_1D.format(price=price)
                 user.notified_1d = True
-            elif days == 3 and not user.notified_3d:
+            elif delta <= timedelta(days=3) and not user.notified_3d:
                 text = SUB_END_3D.format(price=price)
                 user.notified_3d = True
-            elif days == 7 and not user.notified_7d:
+            elif delta <= timedelta(days=7) and not user.notified_7d:
                 text = SUB_END_7D.format(price=price)
                 user.notified_7d = True
             if text:


### PR DESCRIPTION
## Summary
- compute subscription reminder timing from the precise period end timestamp
- keep the 0/1/3/7-day notifications tied to the user’s actual payment time rather than midnight

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*


------
https://chatgpt.com/codex/tasks/task_e_68cb028a8fac832ea3ec4e80578debf0