### PR TITLE
Handle body fat illustration fallback when imghdr fails

### DIFF
--- a/bot/handlers/goals.py
+++ b/bot/handlers/goals.py
@@ -1,11 +1,13 @@
 import logging
 import imghdr
+from io import BytesIO
 
 from aiogram import types, Dispatcher, F
 from aiogram.exceptions import TelegramBadRequest
 from aiogram.types import BufferedInputFile
 from aiogram.fsm.context import FSMContext
 from aiogram.filters import StateFilter
+from PIL import Image, UnidentifiedImageError
 
 from ..database import SessionLocal, Goal, Meal, get_option_bool
 from ..subscriptions import ensure_user, update_limits
@@ -125,14 +127,31 @@ def _load_goal_body_fat_photo() -> Optional[Tuple[BufferedInputFile, Path]]:
         return None
     image_format = imghdr.what(None, payload)
     if image_format not in {"jpeg", "png"}:
-        logger.warning(
-            "Body fat illustration %s has unsupported format %s", image_path, image_format
-        )
-        return None
+        try:
+            with Image.open(BytesIO(payload)) as illustration:
+                pil_format = (illustration.format or "").lower()
+                if pil_format in {"jpeg", "png"}:
+                    image_format = pil_format
+                elif pil_format:
+                    buffer = BytesIO()
+                    illustration.convert("RGB").save(buffer, format="JPEG")
+                    payload = buffer.getvalue()
+                    image_format = "jpeg"
+                else:
+                    raise UnidentifiedImageError
+        except UnidentifiedImageError:
+            logger.warning(
+                "Body fat illustration %s has unsupported format %s", image_path, image_format
+            )
+            return None
     filename = image_path.name
     if "." not in filename:
         extension = "jpg" if image_format == "jpeg" else "png"
         filename = f"{filename}.{extension}"
+    elif image_format == "jpeg" and not filename.lower().endswith((".jpg", ".jpeg")):
+        filename = f"{image_path.stem}.jpg"
+    elif image_format == "png" and not filename.lower().endswith(".png"):
+        filename = f"{image_path.stem}.png"
     return BufferedInputFile(payload, filename=filename), image_path
 
 

--- a/tests/test_goal_body_fat_image.py
+++ b/tests/test_goal_body_fat_image.py
@@ -1,0 +1,27 @@
+import os
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot.handlers import goals  # noqa: E402
+
+
+def test_load_goal_body_fat_photo_falls_back_to_pillow(monkeypatch, tmp_path):
+    image_path = tmp_path / "goal_body_fat.png"
+    Image.new("RGB", (10, 10), color="red").save(image_path, format="PNG")
+
+    monkeypatch.setattr(goals, "STATIC_DIR", tmp_path)
+    monkeypatch.setattr(goals, "GOAL_BODY_FAT_IMAGE_NAME", image_path.name)
+    monkeypatch.setattr(goals.imghdr, "what", lambda *_, **__: None)
+
+    result = goals._load_goal_body_fat_photo()
+
+    assert result is not None
+    buffered_file, returned_path = result
+    assert returned_path == image_path
+    assert buffered_file.filename.endswith(".png")
+    assert buffered_file.data


### PR DESCRIPTION
## Summary
- fall back to Pillow to detect or convert the body fat illustration when imghdr fails so supported images are sent
- normalize the generated filename extension for Telegram uploads
- add a regression test covering the fallback loader logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5975ab5f8832e8545cdee285fbdda