### PR TITLE
Detect invalid goal body fat illustration

### DIFF
--- a/tests/test_goal_body_fat_image.py
+++ b/tests/test_goal_body_fat_image.py
@@ -1,0 +1,79 @@
+import imghdr
+import os
+import sys
+from pathlib import Path
+
+from PIL import Image, UnidentifiedImageError
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot.handlers import goals  # noqa: E402
+
+
+def test_load_goal_body_fat_photo_falls_back_to_pillow(monkeypatch, tmp_path):
+    image_path = tmp_path / "goal_body_fat.png"
+    Image.new("RGB", (10, 10), color="red").save(image_path, format="PNG")
+
+    monkeypatch.setattr(goals, "STATIC_DIR", tmp_path)
+    monkeypatch.setattr(goals, "GOAL_BODY_FAT_IMAGE_NAME", image_path.name)
+    monkeypatch.setattr(goals.imghdr, "what", lambda *_, **__: None)
+
+    result = goals._load_goal_body_fat_photo()
+
+    assert result is not None
+    buffered_file, returned_path = result
+    assert returned_path == image_path
+    assert buffered_file.filename.endswith(".png")
+    assert buffered_file.data
+
+
+def test_load_goal_body_fat_photo_detects_signature_when_pillow_fails(monkeypatch, tmp_path):
+    image_path = tmp_path / "goal_body_fat.png"
+    Image.new("RGB", (10, 10), color="blue").save(image_path, format="PNG")
+
+    monkeypatch.setattr(goals, "STATIC_DIR", tmp_path)
+    monkeypatch.setattr(goals, "GOAL_BODY_FAT_IMAGE_NAME", image_path.name)
+    monkeypatch.setattr(goals.imghdr, "what", lambda *_, **__: None)
+
+    def raise_unidentified(*_args, **_kwargs):
+        raise UnidentifiedImageError("cannot identify image")
+
+    monkeypatch.setattr(goals.Image, "open", raise_unidentified)
+
+    result = goals._load_goal_body_fat_photo()
+
+    assert result is not None
+    buffered_file, returned_path = result
+    assert returned_path == image_path
+    assert buffered_file.filename.endswith(".png")
+    assert buffered_file.data
+
+
+def test_load_goal_body_fat_photo_rejects_corrupted_file(monkeypatch, tmp_path):
+    image_path = tmp_path / "goal_body_fat.png"
+    image_path.write_bytes(b"not a real png")
+
+    monkeypatch.setattr(goals, "STATIC_DIR", tmp_path)
+    monkeypatch.setattr(goals, "GOAL_BODY_FAT_IMAGE_NAME", image_path.name)
+
+    result = goals._load_goal_body_fat_photo()
+
+    assert result is None
+
+
+def test_load_goal_body_fat_photo_converts_unsupported_format(monkeypatch, tmp_path):
+    image_path = tmp_path / "goal_body_fat.tiff"
+    Image.new("RGB", (10, 10), color="green").save(image_path, format="TIFF")
+
+    monkeypatch.setattr(goals, "STATIC_DIR", tmp_path)
+    monkeypatch.setattr(goals, "GOAL_BODY_FAT_IMAGE_NAME", image_path.name)
+
+    result = goals._load_goal_body_fat_photo()
+
+    assert result is not None
+    buffered_file, returned_path = result
+    assert returned_path == image_path
+    assert buffered_file.filename.endswith(".jpg")
+    assert buffered_file.data
+    assert imghdr.what(None, buffered_file.data) == "jpeg"


### PR DESCRIPTION
## Summary
- detect PNG/JPEG signatures for the goal body fat illustration before normalisation and warn when the asset is not a valid PNG/JPEG
- extend the regression suite with coverage for signature fallback and corrupted body fat assets

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5975ab5f8832e8545cdee285fbdda