### PR TITLE
Fix typing union support for Python 3.9

### DIFF
--- a/bot/storage.py
+++ b/bot/storage.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict, Optional
 import os
 import time


### PR DESCRIPTION
## Summary
- add future annotations import so typing union syntax works on Python 3.9

## Testing
- pytest *(fails: missing pytest_asyncio dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d964eecfe8832eace13f6bce5baa64