### PR TITLE
Improve cleanup maintenance and add storage tests

### DIFF
--- a/bot/cleanup.py
+++ b/bot/cleanup.py
@@ -2,35 +2,48 @@ import asyncio
 import os
 import tempfile
 import time
+from typing import Optional
+
 from .storage import pending_meals, remove_photo_if_unused
 
 PREFIX = "diet_photo_"
 RETENTION_DAYS = 7
+STALE_PENDING_SECONDS = 3600
+
+
+def run_cleanup_cycle(*, now: Optional[float] = None, temp_dir: Optional[str] = None) -> None:
+    """Perform a single cleanup pass over temp files and pending meals."""
+
+    current_time = now if now is not None else time.time()
+    cutoff = current_time - RETENTION_DAYS * 24 * 3600
+    directory = temp_dir or tempfile.gettempdir()
+
+    for name in os.listdir(directory):
+        if not name.startswith(PREFIX):
+            continue
+        path = os.path.join(directory, name)
+        try:
+            if os.path.getmtime(path) < cutoff:
+                os.remove(path)
+        except FileNotFoundError:
+            pass
+        except Exception:
+            pass
+
+    stale_cutoff = current_time - STALE_PENDING_SECONDS
+    for meal_id, meal in list(pending_meals.items()):
+        timestamp = meal.get("timestamp")
+        path = meal.get("photo_path")
+        if timestamp and timestamp < stale_cutoff:
+            if path:
+                remove_photo_if_unused(path, ignore_id=meal_id)
+            pending_meals.pop(meal_id, None)
 
 
 def cleanup_watcher(check_interval: int = 60):
     async def _cleanup():
         while True:
-            now = time.time()
-            cutoff = now - RETENTION_DAYS * 24 * 3600
-            temp_dir = tempfile.gettempdir()
-            for name in os.listdir(temp_dir):
-                if name.startswith(PREFIX):
-                    path = os.path.join(temp_dir, name)
-                    try:
-                        if os.path.getmtime(path) < cutoff:
-                            os.remove(path)
-                    except FileNotFoundError:
-                        pass
-                    except Exception:
-                        pass
-            # remove stale photos from pending meals
-            stale = now - 3600
-            for mid, meal in list(pending_meals.items()):
-                ts = meal.get("timestamp")
-                path = meal.get("photo_path")
-                if path and ts and ts < stale:
-                    remove_photo_if_unused(path, mid)
-                    meal["photo_path"] = None
+            run_cleanup_cycle()
             await asyncio.sleep(check_interval)
+
     return _cleanup

--- a/bot/handlers/goals.py
+++ b/bot/handlers/goals.py
@@ -1,4 +1,5 @@
 import logging
+import inspect
 import imghdr
 from io import BytesIO
 
@@ -95,7 +96,9 @@ async def _delete_message_safely(bot, chat_id: int, message_id: Optional[int]) -
     if not message_id:
         return
     try:
-        await bot.delete_message(chat_id, message_id)
+        result = bot.delete_message(chat_id, message_id)
+        if inspect.isawaitable(result):
+            await result
     except TelegramBadRequest:
         pass
 

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,0 +1,79 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot.cleanup import (  # noqa: E402
+    PREFIX,
+    RETENTION_DAYS,
+    STALE_PENDING_SECONDS,
+    run_cleanup_cycle,
+)
+from bot import storage  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def clear_pending_meals():
+    storage.pending_meals.clear()
+    yield
+    storage.pending_meals.clear()
+
+
+def _touch(path: os.PathLike[str], mtime: float) -> None:
+    os.utime(path, (mtime, mtime))
+
+
+def test_run_cleanup_cycle_removes_stale_entries(tmp_path):
+    now = 1_000_000.0
+    old_file = tmp_path / f"{PREFIX}old.jpg"
+    old_file.write_text("data")
+    stale_file_time = now - (RETENTION_DAYS * 24 * 3600 + 10)
+    _touch(old_file, stale_file_time)
+
+    meal_id = "user_1"
+    storage.pending_meals[meal_id] = {
+        "timestamp": now - STALE_PENDING_SECONDS - 1,
+        "photo_path": str(old_file),
+    }
+
+    run_cleanup_cycle(now=now, temp_dir=str(tmp_path))
+
+    assert meal_id not in storage.pending_meals
+    assert not old_file.exists()
+
+
+def test_run_cleanup_cycle_keeps_recent_entries(tmp_path):
+    now = 2_000_000.0
+    fresh_file = tmp_path / f"{PREFIX}fresh.jpg"
+    fresh_file.write_text("data")
+    _touch(fresh_file, now - 60)
+
+    meal_id = "user_recent"
+    storage.pending_meals[meal_id] = {
+        "timestamp": now - 10,
+        "photo_path": str(fresh_file),
+    }
+
+    run_cleanup_cycle(now=now, temp_dir=str(tmp_path))
+
+    assert meal_id in storage.pending_meals
+    assert storage.pending_meals[meal_id]["photo_path"] == str(fresh_file)
+    assert fresh_file.exists()
+
+
+def test_document_prompt_cooldown_and_reset(monkeypatch):
+    storage._document_photo_reminders.clear()
+
+    monkeypatch.setattr(storage.time, "time", lambda: 1000.0)
+    assert storage.should_send_document_prompt(123, cooldown=10) is True
+    assert storage.should_send_document_prompt(123, cooldown=10) is False
+
+    storage.reset_document_prompt(123)
+    monkeypatch.setattr(storage.time, "time", lambda: 1005.0)
+    assert storage.should_send_document_prompt(123, cooldown=10) is False
+
+    monkeypatch.setattr(storage.time, "time", lambda: 1011.0)
+    assert storage.should_send_document_prompt(123, cooldown=10) is True

--- a/tests/test_goal_process_input.py
+++ b/tests/test_goal_process_input.py
@@ -10,6 +10,7 @@ os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+from bot.handlers import goals  # noqa: E402
 from bot.handlers.goals import process_age, process_weight, GoalState  # noqa: E402
 from bot.keyboards import goal_back_kb, goal_body_fat_kb  # noqa: E402
 from bot.texts import GOAL_ENTER_HEIGHT, GOAL_CHOOSE_BODY_FAT  # noqa: E402
@@ -43,7 +44,7 @@ async def test_process_age_edits_prompt_and_deletes_input():
 
 
 @pytest.mark.asyncio
-async def test_process_weight_moves_to_activity_and_deletes_input():
+async def test_process_weight_moves_to_activity_and_deletes_input(monkeypatch):
     message = MagicMock()
     message.text = "70"
     message.chat.id = 1
@@ -55,6 +56,8 @@ async def test_process_weight_moves_to_activity_and_deletes_input():
 
     state = AsyncMock()
     state.get_data.return_value = {"msg_id": 99}
+
+    monkeypatch.setattr(goals, "GOAL_BODY_FAT_IMAGE_NAME", "")
 
     await process_weight(message, state)
 


### PR DESCRIPTION
## Summary
- refactor the cleanup watcher to reuse a single-cycle helper that drops stale temp files and pending meal entries
- make goal message deletion tolerate synchronous mocks when called during tests
- cover cleanup and prompt cooldown behaviour with new tests and adjust the weight flow test to exercise the fallback path

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc1533b474832eb5718e3ae2f1a7b8