### PR TITLE
Improve mass notification logging and retries

### DIFF
--- a/bot/engagement.py
+++ b/bot/engagement.py
@@ -5,6 +5,8 @@ from aiogram import Bot
 
 from .database import SessionLocal, User, Meal, EngagementStatus
 from .keyboards import subscribe_button, feedback_button
+from .logger import log
+from .messaging import send_with_retries
 from .storage import pending_meals
 from .settings import SUPPORT_HANDLE
 from .texts import (
@@ -26,6 +28,36 @@ from .texts import (
 )
 
 
+async def _send(
+    bot: Bot,
+    chat_id: int,
+    text: str,
+    *,
+    event: str | None = None,
+    reply_markup=None,
+    **kwargs,
+) -> bool:
+    """Send engagement messages with retries and logging."""
+
+    send_kwargs = {}
+    if reply_markup is not None:
+        send_kwargs["reply_markup"] = reply_markup
+    send_kwargs.update(kwargs)
+    delivered = await send_with_retries(
+        bot,
+        chat_id,
+        text=text,
+        category="engagement",
+        **send_kwargs,
+    )
+    label = event or text
+    if delivered:
+        log("engagement", "delivered %s to %s", label, chat_id)
+    else:
+        log("engagement", "failed to deliver %s to %s", label, chat_id)
+    return delivered
+
+
 async def process_request_events(bot: Bot, telegram_id: int) -> None:
     """Handle engagement events triggered by a new GPT request."""
     session = SessionLocal()
@@ -41,24 +73,30 @@ async def process_request_events(bot: Bot, telegram_id: int) -> None:
     prev_ts = user.last_request
 
     if not eng.first_request_sent and user.requests_total >= 1:
-        try:
-            await bot.send_message(user.telegram_id, FIRST_REQUEST_DONE)
-        except Exception:
-            pass
+        await _send(
+            bot,
+            user.telegram_id,
+            FIRST_REQUEST_DONE,
+            event="first request milestone",
+        )
         eng.first_request_sent = True
 
     if not eng.three_requests_sent and user.requests_total >= 3:
-        try:
-            await bot.send_message(user.telegram_id, THREE_REQUESTS_DONE)
-        except Exception:
-            pass
+        await _send(
+            bot,
+            user.telegram_id,
+            THREE_REQUESTS_DONE,
+            event="three requests milestone",
+        )
         eng.three_requests_sent = True
 
     if not eng.seven_requests_sent and user.requests_total >= 7:
-        try:
-            await bot.send_message(user.telegram_id, SEVEN_REQUESTS_DONE)
-        except Exception:
-            pass
+        await _send(
+            bot,
+            user.telegram_id,
+            SEVEN_REQUESTS_DONE,
+            event="seven requests milestone",
+        )
         eng.seven_requests_sent = True
 
     if (
@@ -66,30 +104,26 @@ async def process_request_events(bot: Bot, telegram_id: int) -> None:
         and user.requests_total >= 5
         and session.query(Meal).filter_by(user_id=user.id).count() == 0
     ):
-        try:
-            meals = [
-                m
-                for m in pending_meals.values()
-                if m.get("chat_id") == user.telegram_id and m.get("message_id")
-            ]
-            msg_id = None
-            if meals:
-                latest = max(meals, key=lambda m: m.get("timestamp", 0))
-                msg_id = latest.get("message_id")
-            await bot.send_message(
-                user.telegram_id,
-                NO_MEAL_AFTER_REQUESTS,
-                reply_to_message_id=msg_id,
-            )
-        except Exception:
-            pass
+        meals = [
+            m
+            for m in pending_meals.values()
+            if m.get("chat_id") == user.telegram_id and m.get("message_id")
+        ]
+        msg_id = None
+        if meals:
+            latest = max(meals, key=lambda m: m.get("timestamp", 0))
+            msg_id = latest.get("message_id")
+        await _send(
+            bot,
+            user.telegram_id,
+            NO_MEAL_AFTER_REQUESTS,
+            event="no meal reminder",
+            reply_to_message_id=msg_id,
+        )
         eng.five_no_meal_sent = True
 
     if prev_ts and now - prev_ts >= timedelta(days=7):
-        try:
-            await bot.send_message(user.telegram_id, WELCOME_BACK)
-        except Exception:
-            pass
+        await _send(bot, user.telegram_id, WELCOME_BACK, event="welcome back reminder")
     eng.inactivity_7d_sent = False
     eng.inactivity_14d_sent = False
     eng.inactivity_30d_sent = False
@@ -118,28 +152,34 @@ def engagement_watcher(check_interval: int = 60):
                         not eng.no_request_15m
                         and delta >= timedelta(minutes=15)
                     ):
-                        try:
-                            await bot.send_message(user.telegram_id, WELCOME_REMINDER_15M)
-                        except Exception:
-                            pass
+                        await _send(
+                            bot,
+                            user.telegram_id,
+                            WELCOME_REMINDER_15M,
+                            event="welcome reminder 15m",
+                        )
                         eng.no_request_15m = True
                     if (
                         not eng.no_request_24h
                         and delta >= timedelta(hours=24)
                     ):
-                        try:
-                            await bot.send_message(user.telegram_id, WELCOME_REMINDER_24H)
-                        except Exception:
-                            pass
+                        await _send(
+                            bot,
+                            user.telegram_id,
+                            WELCOME_REMINDER_24H,
+                            event="welcome reminder 24h",
+                        )
                         eng.no_request_24h = True
                     if (
                         not eng.no_request_3d
                         and delta >= timedelta(days=3)
                     ):
-                        try:
-                            await bot.send_message(user.telegram_id, WELCOME_REMINDER_3D)
-                        except Exception:
-                            pass
+                        await _send(
+                            bot,
+                            user.telegram_id,
+                            WELCOME_REMINDER_3D,
+                            event="welcome reminder 3d",
+                        )
                         eng.no_request_3d = True
 
                 # 10-day feedback
@@ -148,14 +188,13 @@ def engagement_watcher(check_interval: int = 60):
                     and now - (user.created_at or now) >= timedelta(days=10)
                 ):
                     url = f"https://t.me/{SUPPORT_HANDLE.lstrip('@')}"
-                    try:
-                        await bot.send_message(
-                            user.telegram_id,
-                            FEEDBACK_10D,
-                            reply_markup=feedback_button(url),
-                        )
-                    except Exception:
-                        pass
+                    await _send(
+                        bot,
+                        user.telegram_id,
+                        FEEDBACK_10D,
+                        event="feedback reminder 10d",
+                        reply_markup=feedback_button(url),
+                    )
                     eng.feedback_10d_sent = True
 
                 # free limit reminder
@@ -171,14 +210,13 @@ def engagement_watcher(check_interval: int = 60):
                         and not eng.limit_reminder_sent
                         and now - eng.limit_reached_at >= timedelta(days=3)
                     ):
-                        try:
-                            await bot.send_message(
-                                user.telegram_id,
-                                FREE_LIMIT_PAY_REMINDER,
-                                reply_markup=subscribe_button(BTN_REMOVE_LIMITS),
-                            )
-                        except Exception:
-                            pass
+                        await _send(
+                            bot,
+                            user.telegram_id,
+                            FREE_LIMIT_PAY_REMINDER,
+                            event="free limit reminder",
+                            reply_markup=subscribe_button(BTN_REMOVE_LIMITS),
+                        )
                         eng.limit_reminder_sent = True
                 else:
                     eng.limit_reached_at = None
@@ -189,22 +227,28 @@ def engagement_watcher(check_interval: int = 60):
                 if last_ts:
                     days = (now - last_ts).days
                     if days >= 30 and not eng.inactivity_30d_sent:
-                        try:
-                            await bot.send_message(user.telegram_id, INACTIVE_30D)
-                        except Exception:
-                            pass
+                        await _send(
+                            bot,
+                            user.telegram_id,
+                            INACTIVE_30D,
+                            event="inactive 30d",
+                        )
                         eng.inactivity_30d_sent = True
                     elif days >= 14 and not eng.inactivity_14d_sent:
-                        try:
-                            await bot.send_message(user.telegram_id, INACTIVE_14D)
-                        except Exception:
-                            pass
+                        await _send(
+                            bot,
+                            user.telegram_id,
+                            INACTIVE_14D,
+                            event="inactive 14d",
+                        )
                         eng.inactivity_14d_sent = True
                     elif days >= 7 and not eng.inactivity_7d_sent:
-                        try:
-                            await bot.send_message(user.telegram_id, INACTIVE_7D)
-                        except Exception:
-                            pass
+                        await _send(
+                            bot,
+                            user.telegram_id,
+                            INACTIVE_7D,
+                            event="inactive 7d",
+                        )
                         eng.inactivity_7d_sent = True
 
             session.commit()
@@ -217,14 +261,13 @@ def engagement_watcher(check_interval: int = 60):
                 if ts and now_ts - ts > 1800 and not meal.get("reminded"):
                     chat_id = meal.get("chat_id")
                     msg_id = meal.get("message_id")
-                    try:
-                        await bot.send_message(
-                            chat_id,
-                            ADD_MEAL_REMINDER,
-                            reply_to_message_id=msg_id,
-                        )
-                    except Exception:
-                        pass
+                    await _send(
+                        bot,
+                        chat_id,
+                        ADD_MEAL_REMINDER,
+                        event="pending meal reminder",
+                        reply_to_message_id=msg_id,
+                    )
                     meal["reminded"] = True
 
             await asyncio.sleep(check_interval)


### PR DESCRIPTION
## Summary
- add retry-aware helper for reminder deliveries with explicit logging
- route engagement workflows through a shared sender that logs successes and failures
- unify subscription notifications on a reusable sender to capture delivery outcomes

## Testing
- pytest *(fails: missing pytest_asyncio)*

------
https://chatgpt.com/codex/tasks/task_e_68dc327ed628832ea13802c5253becae