### PR TITLE
Fix mass messaging compatibility and delivery tracking

### DIFF
--- a/bot/engagement.py
+++ b/bot/engagement.py
@@ -1,10 +1,14 @@
 import asyncio
 import time
 from datetime import datetime, timedelta
+from typing import Optional
+
 from aiogram import Bot
 
 from .database import SessionLocal, User, Meal, EngagementStatus
 from .keyboards import subscribe_button, feedback_button
+from .logger import log
+from .messaging import send_with_retries
 from .storage import pending_meals
 from .settings import SUPPORT_HANDLE
 from .texts import (
@@ -26,6 +30,36 @@ from .texts import (
 )
 
 
+async def _send(
+    bot: Bot,
+    chat_id: int,
+    text: str,
+    *,
+    event: Optional[str] = None,
+    reply_markup=None,
+    **kwargs,
+) -> bool:
+    """Send engagement messages with retries and logging."""
+
+    send_kwargs = {}
+    if reply_markup is not None:
+        send_kwargs["reply_markup"] = reply_markup
+    send_kwargs.update(kwargs)
+    delivered = await send_with_retries(
+        bot,
+        chat_id,
+        text=text,
+        category="engagement",
+        **send_kwargs,
+    )
+    label = event or text
+    if delivered:
+        log("engagement", "delivered %s to %s", label, chat_id)
+    else:
+        log("engagement", "failed to deliver %s to %s", label, chat_id)
+    return delivered
+
+
 async def process_request_events(bot: Bot, telegram_id: int) -> None:
     """Handle engagement events triggered by a new GPT request."""
     session = SessionLocal()
@@ -41,55 +75,62 @@ async def process_request_events(bot: Bot, telegram_id: int) -> None:
     prev_ts = user.last_request
 
     if not eng.first_request_sent and user.requests_total >= 1:
-        try:
-            await bot.send_message(user.telegram_id, FIRST_REQUEST_DONE)
-        except Exception:
-            pass
-        eng.first_request_sent = True
+        if await _send(
+            bot,
+            user.telegram_id,
+            FIRST_REQUEST_DONE,
+            event="first request milestone",
+        ):
+            eng.first_request_sent = True
 
     if not eng.three_requests_sent and user.requests_total >= 3:
-        try:
-            await bot.send_message(user.telegram_id, THREE_REQUESTS_DONE)
-        except Exception:
-            pass
-        eng.three_requests_sent = True
+        if await _send(
+            bot,
+            user.telegram_id,
+            THREE_REQUESTS_DONE,
+            event="three requests milestone",
+        ):
+            eng.three_requests_sent = True
 
     if not eng.seven_requests_sent and user.requests_total >= 7:
-        try:
-            await bot.send_message(user.telegram_id, SEVEN_REQUESTS_DONE)
-        except Exception:
-            pass
-        eng.seven_requests_sent = True
+        if await _send(
+            bot,
+            user.telegram_id,
+            SEVEN_REQUESTS_DONE,
+            event="seven requests milestone",
+        ):
+            eng.seven_requests_sent = True
 
     if (
         not eng.five_no_meal_sent
         and user.requests_total >= 5
         and session.query(Meal).filter_by(user_id=user.id).count() == 0
     ):
-        try:
-            meals = [
-                m
-                for m in pending_meals.values()
-                if m.get("chat_id") == user.telegram_id and m.get("message_id")
-            ]
-            msg_id = None
-            if meals:
-                latest = max(meals, key=lambda m: m.get("timestamp", 0))
-                msg_id = latest.get("message_id")
-            await bot.send_message(
-                user.telegram_id,
-                NO_MEAL_AFTER_REQUESTS,
-                reply_to_message_id=msg_id,
-            )
-        except Exception:
-            pass
-        eng.five_no_meal_sent = True
+        meals = [
+            m
+            for m in pending_meals.values()
+            if m.get("chat_id") == user.telegram_id and m.get("message_id")
+        ]
+        msg_id = None
+        if meals:
+            latest = max(meals, key=lambda m: m.get("timestamp", 0))
+            msg_id = latest.get("message_id")
+        if await _send(
+            bot,
+            user.telegram_id,
+            NO_MEAL_AFTER_REQUESTS,
+            event="no meal reminder",
+            reply_to_message_id=msg_id,
+        ):
+            eng.five_no_meal_sent = True
 
     if prev_ts and now - prev_ts >= timedelta(days=7):
-        try:
-            await bot.send_message(user.telegram_id, WELCOME_BACK)
-        except Exception:
-            pass
+        await _send(
+            bot,
+            user.telegram_id,
+            WELCOME_BACK,
+            event="welcome back reminder",
+        )
     eng.inactivity_7d_sent = False
     eng.inactivity_14d_sent = False
     eng.inactivity_30d_sent = False
@@ -118,29 +159,35 @@ def engagement_watcher(check_interval: int = 60):
                         not eng.no_request_15m
                         and delta >= timedelta(minutes=15)
                     ):
-                        try:
-                            await bot.send_message(user.telegram_id, WELCOME_REMINDER_15M)
-                        except Exception:
-                            pass
-                        eng.no_request_15m = True
+                        if await _send(
+                            bot,
+                            user.telegram_id,
+                            WELCOME_REMINDER_15M,
+                            event="welcome reminder 15m",
+                        ):
+                            eng.no_request_15m = True
                     if (
                         not eng.no_request_24h
                         and delta >= timedelta(hours=24)
                     ):
-                        try:
-                            await bot.send_message(user.telegram_id, WELCOME_REMINDER_24H)
-                        except Exception:
-                            pass
-                        eng.no_request_24h = True
+                        if await _send(
+                            bot,
+                            user.telegram_id,
+                            WELCOME_REMINDER_24H,
+                            event="welcome reminder 24h",
+                        ):
+                            eng.no_request_24h = True
                     if (
                         not eng.no_request_3d
                         and delta >= timedelta(days=3)
                     ):
-                        try:
-                            await bot.send_message(user.telegram_id, WELCOME_REMINDER_3D)
-                        except Exception:
-                            pass
-                        eng.no_request_3d = True
+                        if await _send(
+                            bot,
+                            user.telegram_id,
+                            WELCOME_REMINDER_3D,
+                            event="welcome reminder 3d",
+                        ):
+                            eng.no_request_3d = True
 
                 # 10-day feedback
                 if (
@@ -148,15 +195,14 @@ def engagement_watcher(check_interval: int = 60):
                     and now - (user.created_at or now) >= timedelta(days=10)
                 ):
                     url = f"https://t.me/{SUPPORT_HANDLE.lstrip('@')}"
-                    try:
-                        await bot.send_message(
-                            user.telegram_id,
-                            FEEDBACK_10D,
-                            reply_markup=feedback_button(url),
-                        )
-                    except Exception:
-                        pass
-                    eng.feedback_10d_sent = True
+                    if await _send(
+                        bot,
+                        user.telegram_id,
+                        FEEDBACK_10D,
+                        event="feedback reminder 10d",
+                        reply_markup=feedback_button(url),
+                    ):
+                        eng.feedback_10d_sent = True
 
                 # free limit reminder
                 if user.grade == "free":
@@ -171,15 +217,14 @@ def engagement_watcher(check_interval: int = 60):
                         and not eng.limit_reminder_sent
                         and now - eng.limit_reached_at >= timedelta(days=3)
                     ):
-                        try:
-                            await bot.send_message(
-                                user.telegram_id,
-                                FREE_LIMIT_PAY_REMINDER,
-                                reply_markup=subscribe_button(BTN_REMOVE_LIMITS),
-                            )
-                        except Exception:
-                            pass
-                        eng.limit_reminder_sent = True
+                        if await _send(
+                            bot,
+                            user.telegram_id,
+                            FREE_LIMIT_PAY_REMINDER,
+                            event="free limit reminder",
+                            reply_markup=subscribe_button(BTN_REMOVE_LIMITS),
+                        ):
+                            eng.limit_reminder_sent = True
                 else:
                     eng.limit_reached_at = None
                     eng.limit_reminder_sent = False
@@ -189,23 +234,29 @@ def engagement_watcher(check_interval: int = 60):
                 if last_ts:
                     days = (now - last_ts).days
                     if days >= 30 and not eng.inactivity_30d_sent:
-                        try:
-                            await bot.send_message(user.telegram_id, INACTIVE_30D)
-                        except Exception:
-                            pass
-                        eng.inactivity_30d_sent = True
+                        if await _send(
+                            bot,
+                            user.telegram_id,
+                            INACTIVE_30D,
+                            event="inactive 30d",
+                        ):
+                            eng.inactivity_30d_sent = True
                     elif days >= 14 and not eng.inactivity_14d_sent:
-                        try:
-                            await bot.send_message(user.telegram_id, INACTIVE_14D)
-                        except Exception:
-                            pass
-                        eng.inactivity_14d_sent = True
+                        if await _send(
+                            bot,
+                            user.telegram_id,
+                            INACTIVE_14D,
+                            event="inactive 14d",
+                        ):
+                            eng.inactivity_14d_sent = True
                     elif days >= 7 and not eng.inactivity_7d_sent:
-                        try:
-                            await bot.send_message(user.telegram_id, INACTIVE_7D)
-                        except Exception:
-                            pass
-                        eng.inactivity_7d_sent = True
+                        if await _send(
+                            bot,
+                            user.telegram_id,
+                            INACTIVE_7D,
+                            event="inactive 7d",
+                        ):
+                            eng.inactivity_7d_sent = True
 
             session.commit()
             session.close()
@@ -217,15 +268,14 @@ def engagement_watcher(check_interval: int = 60):
                 if ts and now_ts - ts > 1800 and not meal.get("reminded"):
                     chat_id = meal.get("chat_id")
                     msg_id = meal.get("message_id")
-                    try:
-                        await bot.send_message(
-                            chat_id,
-                            ADD_MEAL_REMINDER,
-                            reply_to_message_id=msg_id,
-                        )
-                    except Exception:
-                        pass
-                    meal["reminded"] = True
+                    if await _send(
+                        bot,
+                        chat_id,
+                        ADD_MEAL_REMINDER,
+                        event="pending meal reminder",
+                        reply_to_message_id=msg_id,
+                    ):
+                        meal["reminded"] = True
 
             await asyncio.sleep(check_interval)
 

--- a/bot/messaging.py
+++ b/bot/messaging.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import Iterable, Sequence
+from typing import Iterable, Optional, Sequence
 
 from aiogram import Bot
 from aiogram.exceptions import TelegramAPIError, TelegramRetryAfter
@@ -38,7 +38,7 @@ async def _send_with_retries(
 
     attempt = 0
     delay = base_delay
-    last_error: Exception | None = None
+    last_error: Optional[Exception] = None
     while attempt < retries:
         attempt += 1
         try:

--- a/bot/reminders.py
+++ b/bot/reminders.py
@@ -3,12 +3,14 @@ import random
 import re
 from datetime import datetime, timedelta, time
 from html import escape
+from typing import Optional
 
 from aiogram import Bot
 
 from .database import SessionLocal, User, Meal
 from .keyboards import subscribe_button
 from .logger import log
+from .messaging import send_with_retries
 from .texts import (
     REM_TEXT_MORNING,
     REM_TEXT_DAY,
@@ -100,19 +102,35 @@ def _format_gpt_message(content: str, message_type: str) -> tuple[str, bool]:
     return "\n\n".join(formatted), uses_markup
 
 
-async def _send(bot: Bot, user: User, text: str, reply_markup=None, parse_mode=None) -> None:
-    try:
-        kwargs = {"reply_markup": reply_markup}
-        if parse_mode:
-            kwargs["parse_mode"] = parse_mode
-        await bot.send_message(
-            user.telegram_id,
-            text,
-            **kwargs,
-        )
-        log("notification", "sent reminder to %s: %s", user.telegram_id, text)
-    except Exception:
-        pass
+async def _send(
+    bot: Bot,
+    user: User,
+    text: str,
+    *,
+    reply_markup=None,
+    parse_mode=None,
+    event: Optional[str] = None,
+) -> bool:
+    """Deliver a reminder with retry logic and structured logging."""
+
+    send_kwargs = {}
+    if reply_markup is not None:
+        send_kwargs["reply_markup"] = reply_markup
+    if parse_mode:
+        send_kwargs["parse_mode"] = parse_mode
+    delivered = await send_with_retries(
+        bot,
+        user.telegram_id,
+        text=text,
+        category="notification",
+        **send_kwargs,
+    )
+    label = event or text
+    if delivered:
+        log("notification", "sent reminder to %s: %s", user.telegram_id, label)
+    else:
+        log("notification", "failed to send reminder to %s: %s", user.telegram_id, label)
+    return delivered
 
 
 def reminder_watcher(check_interval: int = 60):
@@ -151,13 +169,14 @@ def reminder_watcher(check_interval: int = 60):
                         if goal:
                             session.delete(goal)
                         if not user.goal_trial_notified:
-                            await _send(
+                            delivered = await _send(
                                 bot,
                                 user,
                                 GOAL_TRIAL_EXPIRED_NOTICE,
                                 reply_markup=subscribe_button(BTN_REMOVE_LIMITS),
                             )
-                        user.goal_trial_notified = True
+                            if delivered:
+                                user.goal_trial_notified = True
                         continue
                 if goal:
                     last_meal = (
@@ -174,7 +193,12 @@ def reminder_watcher(check_interval: int = 60):
                             user.telegram_id,
                         )
                         if user.grade != "free":
-                            await _send(bot, user, GOAL_REMINDERS_DISABLED, reply_markup=None)
+                            await _send(
+                                bot,
+                                user,
+                                GOAL_REMINDERS_DISABLED,
+                                reply_markup=None,
+                            )
                         continue
 
                 if goal and goal.reminder_morning and user.morning_time:
@@ -209,13 +233,14 @@ def reminder_watcher(check_interval: int = 60):
                         log("notification", "morning GPT response for %s: %s", user.telegram_id, content.strip())
                         await token_monitor.add(tokens_in, tokens_out)
                         formatted, use_html = _format_gpt_message(content.strip(), "morning")
-                        await _send(
+                        if await _send(
                             bot,
                             user,
                             formatted,
                             parse_mode="HTML" if use_html else None,
-                        )
-                        user.last_morning = local_now
+                            event="goal morning reminder",
+                        ):
+                            user.last_morning = local_now
                 elif user.morning_enabled and user.morning_time:
                     target = _parse_time(user.morning_time)
                     if (
@@ -223,8 +248,13 @@ def reminder_watcher(check_interval: int = 60):
                         and local_now.time().hour == target.hour
                         and local_now.time().minute == target.minute
                     ):
-                        await _send(bot, user, random.choice(REM_TEXT_MORNING))
-                        user.last_morning = local_now
+                        if await _send(
+                            bot,
+                            user,
+                            random.choice(REM_TEXT_MORNING),
+                            event="morning reminder",
+                        ):
+                            user.last_morning = local_now
 
                 if user.day_enabled and user.day_time:
                     target = _parse_time(user.day_time)
@@ -233,8 +263,13 @@ def reminder_watcher(check_interval: int = 60):
                         and local_now.time().hour == target.hour
                         and local_now.time().minute == target.minute
                     ):
-                        await _send(bot, user, random.choice(REM_TEXT_DAY))
-                        user.last_day = local_now
+                        if await _send(
+                            bot,
+                            user,
+                            random.choice(REM_TEXT_DAY),
+                            event="day reminder",
+                        ):
+                            user.last_day = local_now
 
                 if goal and goal.reminder_evening and user.evening_time:
                     target = _parse_time(user.evening_time)
@@ -270,13 +305,14 @@ def reminder_watcher(check_interval: int = 60):
                         log("notification", "evening GPT response for %s: %s", user.telegram_id, content.strip())
                         await token_monitor.add(tokens_in, tokens_out)
                         formatted, use_html = _format_gpt_message(content.strip(), "evening")
-                        await _send(
+                        if await _send(
                             bot,
                             user,
                             formatted,
                             parse_mode="HTML" if use_html else None,
-                        )
-                        user.last_evening = local_now
+                            event="goal evening reminder",
+                        ):
+                            user.last_evening = local_now
                 elif user.evening_enabled and user.evening_time:
                     target = _parse_time(user.evening_time)
                     if (
@@ -284,8 +320,13 @@ def reminder_watcher(check_interval: int = 60):
                         and local_now.time().hour == target.hour
                         and local_now.time().minute == target.minute
                     ):
-                        await _send(bot, user, random.choice(REM_TEXT_EVENING))
-                        user.last_evening = local_now
+                        if await _send(
+                            bot,
+                            user,
+                            random.choice(REM_TEXT_EVENING),
+                            event="evening reminder",
+                        ):
+                            user.last_evening = local_now
 
             extra_users = (
                 session.query(User)
@@ -306,13 +347,15 @@ def reminder_watcher(check_interval: int = 60):
                     if goal:
                         session.delete(goal)
                     if not user.goal_trial_notified:
-                        await _send(
+                        delivered = await _send(
                             bot,
                             user,
                             GOAL_TRIAL_EXPIRED_NOTICE,
                             reply_markup=subscribe_button(BTN_REMOVE_LIMITS),
+                            event="goal trial expired notice",
                         )
-                    user.goal_trial_notified = True
+                        if delivered:
+                            user.goal_trial_notified = True
             session.commit()
             session.close()
             await asyncio.sleep(check_interval)

--- a/bot/storage.py
+++ b/bot/storage.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 import os
 import time
 
@@ -9,12 +9,13 @@ import time
 pending_meals: Dict[str, Dict] = {}
 
 # track reminder states for invalid photo uploads
-_document_photo_reminders: Dict[int, Dict[str, float | bool]] = {}
-_multi_photo_reminders: Dict[int, Dict[str, float | bool]] = {}
+_ReminderState = Dict[str, Union[float, bool]]
+_document_photo_reminders: Dict[int, _ReminderState] = {}
+_multi_photo_reminders: Dict[int, _ReminderState] = {}
 
 
 def _should_send_prompt(
-    store: Dict[int, Dict[str, float | bool]], user_id: int, cooldown: int
+    store: Dict[int, _ReminderState], user_id: int, cooldown: int
 ) -> bool:
     """Return True if a prompt should be shown, locking it until reset."""
 
@@ -30,7 +31,7 @@ def _should_send_prompt(
     return True
 
 
-def _reset_prompt(store: Dict[int, Dict[str, float | bool]], user_id: int) -> None:
+def _reset_prompt(store: Dict[int, _ReminderState], user_id: int) -> None:
     state = store.get(user_id)
     if state:
         state["locked"] = False


### PR DESCRIPTION
## Summary
- replace Python 3.10 style union annotations with typing.Optional/Union for Python 3.9 compatibility
- only mark engagement, reminder, and subscription notifications as sent when delivery succeeds
- keep reminder prompts reusable while avoiding repeated prompts after failed sends

## Testing
- python -m compileall bot
- pytest *(fails: missing pytest_asyncio)*

------
https://chatgpt.com/codex/tasks/task_e_68dc327ed628832ea13802c5253becae