### PR TITLE
Refactor midnight watchers and goal overflow helper

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import sys
+from datetime import datetime
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -9,6 +10,7 @@ from bot.utils import (  # noqa: E402
     parse_serving,
     make_bar_chart,
     plural_ru_day,
+    seconds_until_next_utc_midnight,
 )
 
 
@@ -41,3 +43,10 @@ def test_plural_ru_day():
     assert plural_ru_day(2) == 'дня'
     assert plural_ru_day(5) == 'дней'
     assert plural_ru_day(11) == 'дней'
+
+
+def test_seconds_until_next_utc_midnight():
+    morning = datetime(2024, 1, 1, 8, 0, 0)
+    evening = datetime(2024, 1, 1, 23, 30, 0)
+    assert seconds_until_next_utc_midnight(morning) == 16 * 3600
+    assert seconds_until_next_utc_midnight(evening) == 30 * 60


### PR DESCRIPTION
## Summary
- refactor goal overflow calculation in `format_meal_message` while relying on context-managed sessions
- add reusable helpers to sleep until the next UTC midnight and wire them into the alert watchers
- extend the utils test suite to cover the new helper

## Testing
- python -m compileall bot
- pytest tests/test_utils.py *(fails: missing pytest_asyncio plugin in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc342dc614832eb575fb69d20e1550