### PR TITLE
Stop reminders for users who blocked the bot

### DIFF
--- a/bot/reminders.py
+++ b/bot/reminders.py
@@ -167,6 +167,8 @@ def reminder_watcher(check_interval: int = 60):
             processed_user_ids = set()
             for user in users:
                 processed_user_ids.add(user.id)
+                if user.blocked or user.left_bot:
+                    continue
                 offset = timedelta(minutes=user.timezone or 0)
                 local_now = now + offset
 
@@ -363,6 +365,8 @@ def reminder_watcher(check_interval: int = 60):
             )
             for user in extra_users:
                 if user.id in processed_user_ids:
+                    continue
+                if user.blocked or user.left_bot:
                     continue
                 if user.grade != "free":
                     if user.goal_trial_start or user.goal_trial_notified:


### PR DESCRIPTION
## Summary
- skip engagement notifications for users marked as having left or blocked the bot
- avoid reminder watcher deliveries, including pending meal pings, for those users

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68e3e5ea5e08832ea753f548e514bc6b